### PR TITLE
Alternative format for listing add-on attachments

### DIFF
--- a/commands/addons.js
+++ b/commands/addons.js
@@ -124,9 +124,9 @@ function formatAttachment(attachment, showApp) {
 
     let attName = style('attachment', attachment.name);
 
-    let output = [attName];
+    let output = [style('dim', 'as'), attName];
     if(showApp) {
-        let appInfo = `➞  to ${style('app', attachment.app.name)} app`;
+        let appInfo = `on ${style('app', attachment.app.name)} app`;
         output.push(style('dim', appInfo));
     }
 


### PR DESCRIPTION
### Before

![screen shot 2015-09-03 at 7 02 45 pm](https://cloud.githubusercontent.com/assets/66427/9675124/6c6e0ed8-526e-11e5-8fa8-68f23e164bdc.png)

---
### After

![screen shot 2015-09-03 at 7 00 29 pm](https://cloud.githubusercontent.com/assets/66427/9675115/55693244-526e-11e5-95aa-dd437c24d5f1.png)

New format is `as HEROKU_POSTGRESQL_COPPER on matthewconway app` rather than `HEROKU_POSTGRESQL_COPPER ➞  to matthewconway app` for listed attachments.

Discuss!

@heroku/add-ons 
