### PR TITLE
lock down dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "iojs"
+  - "4.2.1"
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "co": "^4.6.0",
-    "heroku-cli-util": "^5.4.3",
-    "lodash": "^3.10.1",
-    "printf": "^0.2.3"
+    "co": "4.6.0",
+    "heroku-cli-util": "5.4.13",
+    "lodash": "3.10.1",
+    "printf": "0.2.3"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
Even though we try to stick to semver, it's a good idea to prevent
the plugins from automatically update without releasing a new version
of the plugin with a human around to make sure it is working.