### PR TITLE
addons:open --show-url flag only print the URL

### DIFF
--- a/commands/addons/open.js
+++ b/commands/addons/open.js
@@ -65,11 +65,19 @@ function* run (ctx, api) {
   if (process.env.HEROKU_SUDO) return sudo(ctx, api);
 
   let attachment = yield resolve.attachment(api, ctx.app, ctx.args.addon);
+  let web_url;
+
   if (attachment) {
-    yield open(attachment.web_url);
+    web_url = attachment.web_url;
   } else {
     let addon = yield resolve.addon(api, ctx.app, ctx.args.addon);
-    yield open(addon.web_url);
+    web_url = addon.web_url;
+  }
+
+  if (ctx.flags['show-url']) {
+    cli.log(web_url);
+  } else {
+    yield open(web_url);
   }
 }
 
@@ -79,6 +87,7 @@ module.exports = {
   wantsApp:    true,
   needsAuth:   true,
   args:        [{name: 'addon'}],
+  flags:       [{name: 'show-url', description: 'show URL, do not open browser'}],
   run:         cli.command({preauth: true}, co.wrap(run)),
   description: `open an add-on's dashboard in your browser`
 };

--- a/test/commands/addons/open.js
+++ b/test/commands/addons/open.js
@@ -1,15 +1,27 @@
 'use strict';
 
-let cli        = require('heroku-cli-util');
-cli.open       = require('../../opn');
-let nock       = require('nock');
-let cmd        = commands.find(c => c.topic === 'addons' && c.command === 'open');
-let expect     = require('chai').expect;
+let cli  = require('heroku-cli-util');
+cli.open = require('../../opn');
+let cmd  = commands.find(c => c.topic === 'addons' && c.command === 'open');
 
 describe('addons:open', function() {
   beforeEach(() => cli.mockConsole());
 
-  it('opens the addon dashboard', function() {
+  it('only prints the URL when --show-url passed', function() {
+    let api = nock('https://api.heroku.com:443');
+
+    api.get('/apps/myapp/addons/slowdb')
+        .reply(200, {id: 'slowdb', web_url: 'http://slowdb'});
+
+    api.get('/addons/slowdb/addon-attachments')
+        .reply(200, []);
+
+    return cmd.run({app: 'myapp', args: {addon: 'slowdb'}, flags: {'show-url': true}})
+      .then(() => expect(cli.stdout).to.equal('http://slowdb\n'))
+      .then(() => api.done());
+  });
+
+  it('opens the addon dashboard in a browser by default', function() {
     let api = nock('https://api.heroku.com:443');
 
     api.get('/apps/myapp/addons/slowdb')
@@ -18,7 +30,7 @@ describe('addons:open', function() {
     api.get('/addons/slowdb/addon-attachments')
        .reply(200, []);
 
-    return cmd.run({app: 'myapp', args: {addon: 'slowdb'}})
+    return cmd.run({app: 'myapp', args: {addon: 'slowdb'}, flags: {'show-url': false}})
       .then(() => expect(cli.open.url).to.equal('http://slowdb'))
       .then(() => expect(cli.stdout).to.equal('Opening http://slowdb...\n'))
       .then(() => api.done());
@@ -41,9 +53,10 @@ describe('addons:open', function() {
          {app: {name: 'myapp'},   web_url: 'http://myapp-slowdb'},
          {app: {name: 'myapp-2'}, web_url: 'http://myapp-2-slowdb'}]);
 
-    return cmd.run({app: 'myapp-2', args: {addon: 'slowdb'}})
+    return cmd.run({app: 'myapp-2', args: {addon: 'slowdb'}, flags: {'show-url': false}})
       .then(() => expect(cli.open.url).to.equal('http://myapp-2-slowdb'))
       .then(() => expect(cli.stdout).to.equal('Opening http://myapp-2-slowdb...\n'))
       .then(() => api.done());
   });
+
 });


### PR DESCRIPTION
- Mirrors work done recently on addons:docs (#20)
- Aimed at master where #21 was aimed at the now-merged `docs` branch.