### PR TITLE
remove hpg shorthand

### DIFF
--- a/commands/addons/create.js
+++ b/commands/addons/create.js
@@ -22,21 +22,12 @@ function parseConfig (args) {
   return config
 }
 
-function expandHPG (plan) {
-  if (!plan) throw new Error('Missing requested service or plan')
-  plan = plan.replace(/^hpg:/, 'heroku-postgresql:')
-  plan = plan.replace(/^heroku-postgresql:s-/, 'heroku-postgresql:standard-')
-  plan = plan.replace(/^heroku-postgresql:p-/, 'heroku-postgresql:premium-')
-  plan = plan.replace(/^heroku-postgresql:e-/, 'heroku-postgresql:enterprise-')
-  return plan
-}
-
 function * run (context, heroku) {
   const util = require('../../lib/util')
 
   let {app, flags, args} = context
   let {name, as, confirm} = flags
-  let plan = {name: expandHPG(args.shift())}
+  let plan = {name: args.shift()}
   let config = parseConfig(args)
 
   let addon

--- a/test/commands/addons/create.js
+++ b/test/commands/addons/create.js
@@ -29,7 +29,7 @@ describe('addons:create', () => {
 
     return cmd.run({
       app: 'myapp',
-      args: ['hpg:s-0', '--rollback', '--follow', 'otherdb', '--foo'],
+      args: ['heroku-postgresql:standard-0', '--rollback', '--follow', 'otherdb', '--foo'],
       flags: {as: 'mydb'}
     })
       .then(() => expect(cli.stderr, 'to equal', 'Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))


### PR DESCRIPTION
it has caused us 2 major issues now, and it actually still didn't match
the existing ruby functionality. Also, it only worked for addons:create
but not addons:upgrade so we decided to kill this.

A better solution here would be a more generic aliasing functionality or
a way for add-ons to specify aliases we think.