### PR TITLE
fix create when run twice

### DIFF
--- a/commands/addons/create.js
+++ b/commands/addons/create.js
@@ -27,8 +27,8 @@ function * run (context, heroku) {
 
   let {app, flags, args} = context
   let {name, as, confirm} = flags
-  let plan = {name: args.shift()}
-  let config = parseConfig(args)
+  let plan = {name: args[0]}
+  let config = parseConfig(args.slice(1))
 
   let addon
   yield cli.action(`Creating ${plan.name} on ${cli.color.app(app)}`, co(function * () {


### PR DESCRIPTION
if create has to prompt for a second factor or login, it won't work the
  second time:

```
heroku addons:create heroku-postgresql:standard-0 -a forker
Parsing heroku-cli-addons... done
Creating heroku-postgresql:standard-0 on ⬢ forker... !
 ▸    Invalid credentials provided.
 Enter your Heroku credentials.
 Email: jeff@heroku.com
 Password (typing will be hidden):
 Two-factor code:
 Logged in as jeff@heroku.com
 Creating undefined on ⬢ forker... !
  ▸    Application error.
```