### PR TITLE
Adding confirmation required trap to addons:create

### DIFF
--- a/commands/addons/attach.js
+++ b/commands/addons/attach.js
@@ -4,6 +4,8 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 
 function * run (context, heroku) {
+  const util = require('../../lib/util')
+
   let app = context.app
   let addon = yield heroku.get(`/addons/${encodeURIComponent(context.args.addon_name)}`)
 
@@ -23,12 +25,8 @@ function * run (context, heroku) {
     )
   }
 
-  let attachment = yield createAttachment(app, context.flags.as, context.flags.confirm)
-    .catch((err) => {
-      if (!err.body || err.body.id !== 'confirmation_required') throw err
-      return cli.confirmApp(app, context.flags.confirm, err.body.message)
-        .then(() => createAttachment(app, context.flags.as, app))
-    })
+  let attachment = yield util.trapConfirmationRequired(context, (confirm) => createAttachment(app, context.flags.as, confirm))
+
   yield cli.action(
     `Setting ${cli.color.attachment(attachment.name)} config vars and restarting ${cli.color.app(app)}`,
     {success: false},

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,5 +31,14 @@ module.exports = {
 
     let fmt = price.cents % 100 === 0 ? '$%.0f/%s' : '$%.02f/%s'
     return printf(fmt, price.cents / 100, price.unit)
+  },
+
+  trapConfirmationRequired: function * (context, fn) {
+    return yield fn(context.flags.confirm)
+    .catch((err) => {
+      if (!err.body || err.body.id !== 'confirmation_required') throw err
+      return cli.confirmApp(context.app, context.flags.confirm, err.body.message)
+        .then(() => fn(context.app))
+    })
   }
 }


### PR DESCRIPTION
@dickeyxxx Could you please review?  This is basically a repeat of https://github.com/heroku/heroku-cli-addons/pull/47 but will ship by itself because I reversed out https://github.com/heroku/heroku-cli-addons/pull/47 and @mathias addons wait commits.