### PR TITLE
Bring back async provisioning

### DIFF
--- a/commands/addons/create.js
+++ b/commands/addons/create.js
@@ -2,6 +2,7 @@
 
 const cli = require('heroku-cli-util')
 const co = require('co')
+let waitForAddonProvisioning = require('../../lib/addons_wait')
 
 function parseConfig (args) {
   let config = {}
@@ -29,6 +30,17 @@ function parseConfig (args) {
   return config
 }
 
+function formatConfigVarsMessage (addon) {
+  let configVars = (addon.config_vars || [])
+
+  if (configVars.length > 0) {
+    configVars = configVars.map(c => cli.color.configVar(c)).join(', ')
+    return `Created ${cli.color.addon(addon.name)} as ${configVars}`
+  } else {
+    return `Created ${cli.color.addon(addon.name)}`
+  }
+}
+
 function * run (context, heroku) {
   const util = require('../../lib/util')
 
@@ -54,13 +66,23 @@ function * run (context, heroku) {
 
   let addon = yield util.trapConfirmationRequired(context, (confirm) => (createAddon(app, config, name, confirm, plan, as)))
 
-  if (addon.config_vars.length) {
-    let configVars = addon.config_vars.map(c => cli.color.configVar(c)).join(', ')
-    cli.log(`Created ${cli.color.addon(addon.name)} as ${configVars}`)
+  if (addon.provision_message) { cli.log(addon.provision_message) }
+
+  if (addon.state === 'provisioning') {
+    if (context.flags.wait) {
+      cli.log(`Waiting for ${cli.color.addon(addon.name)}...`)
+      addon = yield waitForAddonProvisioning(context, heroku, addon, 5)
+      cli.log(formatConfigVarsMessage(addon))
+    } else {
+      cli.log(`${cli.color.addon(addon.name)} is being created in the background. The app will restart when complete...`)
+      cli.log(`Use ${cli.color.cmd('heroku addons:info ' + addon.name)} to check creation progress`)
+    }
+  } else if (addon.state === 'deprovisioned') {
+    throw new Error(`The add-on was unable to be created, with status ${addon.state}`)
   } else {
-    cli.log(`Created ${cli.color.addon(addon.name)}`)
+    cli.log(formatConfigVarsMessage(addon))
   }
-  if (addon.provision_message) cli.log(addon.provision_message)
+
   cli.log(`Use ${cli.color.cmd('heroku addons:docs ' + addon.addon_service.name)} to view documentation`)
 }
 
@@ -74,7 +96,8 @@ const cmd = {
   flags: [
     {name: 'name', description: 'name for the add-on resource', hasValue: true},
     {name: 'as', description: 'name for the initial add-on attachment', hasValue: true},
-    {name: 'confirm', description: 'overwrite existing config vars or existing add-on attachments', hasValue: true}
+    {name: 'confirm', description: 'overwrite existing config vars or existing add-on attachments', hasValue: true},
+    {name: 'wait', description: 'watch add-on creation status and exit when complete'}
   ],
   run: cli.command({preauth: true}, co.wrap(run))
 }

--- a/commands/addons/index.js
+++ b/commands/addons/index.js
@@ -8,6 +8,7 @@ function * run (ctx, api) {
   const table = util.table
   const style = util.style
   const formatPrice = util.formatPrice
+  const formatState = util.formatState
   const printf = require('printf')
 
   const groupBy = require('lodash.groupby')
@@ -121,6 +122,23 @@ function * run (ctx, api) {
           if (typeof price === 'undefined') return style('dim', '?')
           return formatPrice(price)
         }
+      },
+      {
+        key: 'state',
+        label: 'State',
+        format: function (state) {
+          switch (state) {
+            case 'provisioned':
+              state = 'created'
+            break
+            case 'provisioning':
+              state = 'creating'
+            break
+            case 'deprovisioned':
+              state = 'errored'
+          }
+          return state
+        }
       }]
     })
   }
@@ -204,6 +222,10 @@ function * run (ctx, api) {
             return style('dim', printf('(billed to %s app)', style('app', addon.app.name)))
           }
         }
+      }, {
+        label: 'State',
+        key: 'state',
+        format: formatState
       }],
 
       // Separate each add-on row by a blank line

--- a/commands/addons/index.js
+++ b/commands/addons/index.js
@@ -130,10 +130,10 @@ function * run (ctx, api) {
           switch (state) {
             case 'provisioned':
               state = 'created'
-            break
+              break
             case 'provisioning':
               state = 'creating'
-            break
+              break
             case 'deprovisioned':
               state = 'errored'
           }

--- a/commands/addons/info.js
+++ b/commands/addons/info.js
@@ -4,6 +4,7 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 
 let formatPrice = require('../../lib/util').formatPrice
+let formatState = require('../../lib/util').formatState
 let style = require('../../lib/util').style
 
 let run = cli.command({preauth: true}, function (ctx, api) {
@@ -27,7 +28,8 @@ let run = cli.command({preauth: true}, function (ctx, api) {
         ].join('::')
       }).sort(),
       'Owning app': style('app', addon.app.name),
-      'Installed at': (new Date(addon.created_at)).toString()
+      'Installed at': (new Date(addon.created_at)).toString(),
+      'State': formatState(addon.state)
     })
   })
 })

--- a/commands/addons/wait.js
+++ b/commands/addons/wait.js
@@ -1,0 +1,35 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+let co = require('co')
+let waitForAddonProvisioning = require('../../lib/addons_wait')
+
+function * run (ctx, api) {
+  const resolve = require('../../lib/resolve')
+  let addon = yield resolve.addon(api, ctx.app, ctx.args.addon, {'Accept-Expansion': 'addon_service,plan'})
+
+  let interval = parseInt(ctx.flags['wait-interval'])
+  if (!interval || interval < 0) { interval = 5 }
+
+  addon = yield waitForAddonProvisioning(ctx, api, addon, interval)
+
+  let configVars = (addon.config_vars || [])
+  if (configVars.length > 0) {
+    configVars = configVars.map(c => cli.color.configVar(c)).join(', ')
+    cli.log(`Created ${cli.color.addon(addon.name)} as ${configVars}`)
+  }
+}
+
+let topic = 'addons'
+
+module.exports = {
+  topic: topic,
+  command: 'wait',
+  wantsApp: true,
+  needsAuth: true,
+  args: [{name: 'addon'}],
+  flags: [{name: 'wait-interval', description: 'how frequently to poll in seconds', hasValue: true}],
+  run: cli.command({preauth: true}, co.wrap(run)),
+  usage: `${topic}:wait ADDON`,
+  description: 'Show provisioning status of the add-ons on the app'
+}

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ exports.commands = flatten([
   require('./commands/addons/plans'),
   require('./commands/addons/rename'),
   require('./commands/addons/services'),
-  require('./commands/addons/upgrade')
+  require('./commands/addons/upgrade'),
+  require('./commands/addons/wait')
 ])
 
 exports.resolve = require('./lib/resolve')

--- a/lib/addons_wait.js
+++ b/lib/addons_wait.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const co = require('co')
+const cli = require('heroku-cli-util')
+
+module.exports = function * (context, api, addon, interval) {
+  const wait = require('co-wait')
+  const app = addon.app.name
+  const addonName = addon.name
+
+  yield cli.action(`Creating ${cli.color.addon(addon.name)}`, co(function * () {
+    while (addon.state === 'provisioning') {
+      yield wait(interval * 1000)
+
+      addon = yield api.request({
+        method: 'GET',
+        path: `/apps/${app}/addons/${addonName}`,
+        headers: {'Accept-Expansion': 'addon_service,plan'}
+      })
+    }
+    if (addon.state === 'deprovisioned') {
+      throw new Error(`The add-on was unable to be created, with status ${addon.state}`)
+    }
+  }))
+
+  return addon
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -40,5 +40,22 @@ module.exports = {
       return cli.confirmApp(context.app, context.flags.confirm, err.body.message)
         .then(() => fn(context.app))
     })
+  },
+
+  formatState: function (state) {
+    switch (state) {
+      case 'provisioned':
+        state = 'created'
+        break
+      case 'provisioning':
+        state = 'creating'
+        break
+      case 'deprovisioned':
+        state = 'errored'
+        break
+      default:
+        state = ''
+    }
+    return state
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "co": "4.6.0",
+    "co-wait": "0.0.0",
     "heroku-cli-util": "6.0.15",
     "lodash.flatten": "4.3.0",
     "lodash.groupby": "4.5.1",

--- a/test/commands/addons.--all.js
+++ b/test/commands/addons.--all.js
@@ -31,11 +31,11 @@ describe('addons --all', function () {
     it('prints add-ons in a table', function () {
       return cmd.run({flags: {}}).then(function () {
         util.expectOutput(cli.stdout,
-          `Owning App    Add-on     Plan                         Price
-────────────  ─────────  ───────────────────────────  ─────────
-acme-inc-api  api-redis  heroku-redis:premium-2       $60/month
-acme-inc-www  www-db     heroku-postgresql:hobby-dev  free
-acme-inc-www  www-redis  heroku-redis:premium-2       $60/month`)
+`Owning App    Add-on     Plan                         Price      State
+────────────  ─────────  ───────────────────────────  ─────────  ────────
+acme-inc-api  api-redis  heroku-redis:premium-2       $60/month  created
+acme-inc-www  www-db     heroku-postgresql:hobby-dev  free       created
+acme-inc-www  www-redis  heroku-redis:premium-2       $60/month  creating`)
       })
     })
 

--- a/test/commands/addons.--app.js
+++ b/test/commands/addons.--app.js
@@ -50,12 +50,12 @@ describe('addons --app', function () {
 
       return run('acme-inc-www', function () {
         util.expectOutput(cli.stdout, `
-Add-on                      Plan       Price
-──────────────────────────  ─────────  ─────────
-heroku-postgresql (www-db)  hobby-dev  free
+Add-on                      Plan       Price      State
+──────────────────────────  ─────────  ─────────  ────────
+heroku-postgresql (www-db)  hobby-dev  free       created
  └─ as DATABASE
 
-heroku-redis (www-redis)    premium-2  $60/month
+heroku-redis (www-redis)    premium-2  $60/month  creating
  └─ as REDIS
 
 The table above shows add-ons and the attachments to the current app (acme-inc-www) or other apps.
@@ -70,9 +70,9 @@ The table above shows add-ons and the attachments to the current app (acme-inc-w
       ])
       return run('acme-inc-www', function () {
         util.expectOutput(cli.stdout, `
-Add-on                             Plan       Price
-─────────────────────────────────  ─────────  ─────
-heroku-postgresql (www-db)         hobby-dev  free
+Add-on                             Plan       Price  State
+─────────────────────────────────  ─────────  ─────  ───────
+heroku-postgresql (www-db)         hobby-dev  free   created
  ├─ as DATABASE
  └─ as WWW_DB on acme-inc-dwh app
 
@@ -89,9 +89,9 @@ The table above shows add-ons and the attachments to the current app (acme-inc-w
 
       return run('acme-inc-dwh', function () {
         util.expectOutput(cli.stdout, `
-Add-on                               Plan       Price
-───────────────────────────────────  ─────────  ────────────────────────────
-heroku-postgresql (www-db)           hobby-dev  (billed to acme-inc-www app)
+Add-on                               Plan       Price                         State
+───────────────────────────────────  ─────────  ────────────────────────────  ───────
+heroku-postgresql (www-db)           hobby-dev  (billed to acme-inc-www app)  created
  ├─ as WWW_DB
  └─ as DATABASE on acme-inc-www app
 
@@ -245,8 +245,8 @@ The table above shows add-ons and the attachments to the current app (acme-inc-d
 
     return run('acme-inc-api', function () {
       util.expectOutput(cli.stdout, `
-Add-on         Plan  Price
-─────────────  ────  ────────────────────────────
+Add-on         Plan  Price                         State
+─────────────  ────  ────────────────────────────  ─────
 ? (www-db)     ?     (billed to acme-inc-www app)
  └─ as WWW_DB
 

--- a/test/commands/addons.--app.js
+++ b/test/commands/addons.--app.js
@@ -241,7 +241,7 @@ The table above shows add-ons and the attachments to the current app (acme-inc-d
   })
 
   it('prints add-on line for attachment when add-on info is missing from API (e.g. no permissions on billing app)', function () {
-    mockAPI('acme-inc-api', [ /* no add-on !*/], [fixtures.attachments['acme-inc-api::WWW_DB']])
+    mockAPI('acme-inc-api', [ /* no add-on ! */], [fixtures.attachments['acme-inc-api::WWW_DB']])
 
     return run('acme-inc-api', function () {
       util.expectOutput(cli.stdout, `

--- a/test/commands/addons/create.js
+++ b/test/commands/addons/create.js
@@ -3,6 +3,8 @@
 
 const cmd = commands.find(c => c.topic === 'addons' && c.command === 'create')
 const expect = require('unexpected')
+const lolex = require('lolex')
+const _ = require('lodash')
 
 describe('addons:create', () => {
   let api
@@ -14,6 +16,7 @@ describe('addons:create', () => {
     app: {name: 'myapp', id: 101},
     config_vars: ['DATABASE_URL'],
     plan: {price: {cents: 10000, unit: 'month'}},
+    state: 'provisioned',
     provision_message: 'provision message'
   }
 
@@ -44,8 +47,8 @@ describe('addons:create', () => {
         flags: {as: 'mydb'}
       })
         .then(() => expect(cli.stderr, 'to equal', 'Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))
-        .then(() => expect(cli.stdout, 'to equal', `Created db3-swiftly-123 as DATABASE_URL
-provision message
+        .then(() => expect(cli.stdout, 'to equal', `provision message
+Created db3-swiftly-123 as DATABASE_URL
 Use heroku addons:docs heroku-db3 to view documentation
 `))
     })
@@ -55,6 +58,161 @@ Use heroku addons:docs heroku-db3 to view documentation
         app: 'myapp',
         args: ['heroku-postgresql:standard-0', '--rollback', '--follow=otherdb', '--foo'],
         flags: {as: 'mydb'}
+      })
+    })
+  })
+  context('when add-on is async', () => {
+    context('provisioning message and config vars provided by add-on provider', () => {
+      beforeEach(() => {
+        let asyncAddon = _.clone(addon)
+
+        asyncAddon.state = 'provisioning'
+
+        api.post('/apps/myapp/addons', {
+          attachment: {name: 'mydb'},
+          config: {},
+          plan: {name: 'heroku-postgresql:standard-0'}
+        })
+        .reply(200, asyncAddon)
+      })
+
+      it('creates an add-on with output about async provisioning', () => {
+        return cmd.run({
+          app: 'myapp',
+          args: ['heroku-postgresql:standard-0'],
+          flags: {as: 'mydb'}
+        })
+          .then(() => expect(cli.stderr, 'to equal', 'Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))
+          .then(() => expect(cli.stdout, 'to equal', `provision message
+db3-swiftly-123 is being created in the background. The app will restart when complete...
+Use heroku addons:info db3-swiftly-123 to check creation progress
+Use heroku addons:docs heroku-db3 to view documentation
+`))
+      })
+    })
+    context('and no provision message supplied', () => {
+      beforeEach(() => {
+        let asyncAddon = _.clone(addon)
+
+        asyncAddon.state = 'provisioning'
+        asyncAddon.provision_message = undefined
+
+        api.post('/apps/myapp/addons', {
+          attachment: {name: 'mydb'},
+          config: {},
+          plan: {name: 'heroku-postgresql:standard-0'}
+        })
+        .reply(200, asyncAddon)
+      })
+
+      it('creates an add-on with output about async provisioning', () => {
+        return cmd.run({
+          app: 'myapp',
+          args: ['heroku-postgresql:standard-0'],
+          flags: {as: 'mydb'}
+        })
+          .then(() => expect(cli.stderr, 'to equal', 'Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))
+          .then(() => expect(cli.stdout, 'to equal', `db3-swiftly-123 is being created in the background. The app will restart when complete...
+Use heroku addons:info db3-swiftly-123 to check creation progress
+Use heroku addons:docs heroku-db3 to view documentation
+`))
+      })
+    })
+    context('and no config vars supplied by add-on provider', () => {
+      beforeEach(() => {
+        let asyncAddon = _.clone(addon)
+
+        asyncAddon.state = 'provisioning'
+        asyncAddon.config_vars = undefined
+
+        api.post('/apps/myapp/addons', {
+          attachment: {name: 'mydb'},
+          config: {},
+          plan: {name: 'heroku-postgresql:standard-0'}
+        })
+        .reply(200, asyncAddon)
+      })
+
+      it('creates an add-on with output about async provisioning', () => {
+        return cmd.run({
+          app: 'myapp',
+          args: ['heroku-postgresql:standard-0'],
+          flags: {as: 'mydb'}
+        })
+          .then(() => expect(cli.stderr, 'to equal', 'Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))
+          .then(() => expect(cli.stdout, 'to equal', `provision message
+db3-swiftly-123 is being created in the background. The app will restart when complete...
+Use heroku addons:info db3-swiftly-123 to check creation progress
+Use heroku addons:docs heroku-db3 to view documentation
+`))
+      })
+    })
+    context('--wait', () => {
+      let clock
+      let post
+      let provisioningResponse
+      let provisionedResponse
+
+      beforeEach(() => {
+        let asyncAddon = _.clone(addon)
+        asyncAddon.state = 'provisioning'
+
+        post = api.post('/apps/myapp/addons', {
+          attachment: {name: 'mydb'},
+          config: {wait: true},
+          plan: {name: 'heroku-postgresql:standard-0'}
+        })
+        .reply(200, asyncAddon)
+
+        provisioningResponse = api.get('/apps/myapp/addons/db3-swiftly-123')
+          .reply(200, asyncAddon)
+
+        provisionedResponse = api.get('/apps/myapp/addons/db3-swiftly-123')
+          .reply(200, addon) // when it has provisioned
+
+        clock = lolex.install()
+        clock.setTimeout = function (fn, timeout) { fn() }
+      })
+
+      afterEach(function () {
+        clock.uninstall()
+      })
+
+      it('waits for response', () => {
+        return cmd.run({
+          app: 'myapp',
+          args: ['heroku-postgresql:standard-0', '--wait'],
+          flags: {as: 'mydb', wait: true}
+        })
+          .then(() => post.done())
+          .then(() => provisioningResponse.done())
+          .then(() => provisionedResponse.done())
+          .then(() => expect(cli.stderr, 'to equal', 'Creating heroku-postgresql:standard-0 on myapp... $100/month\nCreating db3-swiftly-123... done\n'))
+          .then(() => expect(cli.stdout, 'to equal', `provision message
+Waiting for db3-swiftly-123...
+Created db3-swiftly-123 as DATABASE_URL
+Use heroku addons:docs heroku-db3 to view documentation
+`))
+      })
+    })
+    context('when add-on provision errors', () => {
+      it('shows that it failed to provision', function () {
+        let deprovisionedAddon = _.clone(addon)
+        deprovisionedAddon.state = 'deprovisioned'
+
+        api.post('/apps/myapp/addons', {
+          attachment: {name: 'mydb'},
+          plan: {name: 'heroku-postgresql:standard-0'}
+        })
+        .reply(200, deprovisionedAddon) // failed
+
+        let cmdPromise = cmd.run({
+          app: 'myapp',
+          args: ['heroku-postgresql:standard-0'],
+          flags: {as: 'mydb'}
+        })
+
+        expect(cmdPromise, 'to be rejected with', 'The add-on was unable to be created, with status deprovisioned')
       })
     })
   })
@@ -93,8 +251,8 @@ Use heroku addons:docs heroku-db3 to view documentation
         args: ['heroku-postgresql:standard-0', '--rollback', '--follow', 'otherdb', '--foo'],
         flags: {as: 'mydb', confirm: 'myapp'}
       }).then(() => expect(cli.stderr, 'to equal', 'Creating heroku-postgresql:standard-0 on myapp... !\nCreating heroku-postgresql:standard-0 on myapp... $100/month\n'))
-        .then(() => expect(cli.stdout, 'to equal', `Created db3-swiftly-123 as DATABASE_URL
-provision message
+        .then(() => expect(cli.stdout, 'to equal', `provision message
+Created db3-swiftly-123 as DATABASE_URL
 Use heroku addons:docs heroku-db3 to view documentation
 `))
     })
@@ -116,6 +274,32 @@ Use heroku addons:docs heroku-db3 to view documentation
         args: ['heroku-postgresql:standard-0', '--rollback', '--follow=--otherdb', '--foo'],
         flags: {as: 'mydb'}
       })
+    })
+  })
+  context('no config vars supplied by add-on provider', () => {
+    beforeEach(() => {
+      let noConfigAddon = _.clone(addon)
+      noConfigAddon.config_vars = undefined
+
+      api.post('/apps/myapp/addons', {
+        attachment: {name: 'mydb'},
+        config: {},
+        plan: {name: 'heroku-postgresql:standard-0'}
+      })
+      .reply(200, noConfigAddon)
+    })
+
+    it('creates an add-on without the config vars listed', () => {
+      return cmd.run({
+        app: 'myapp',
+        args: ['heroku-postgresql:standard-0'],
+        flags: {as: 'mydb'}
+      })
+        .then(() => expect(cli.stderr, 'to equal', 'Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))
+        .then(() => expect(cli.stdout, 'to equal', `provision message
+Created db3-swiftly-123
+Use heroku addons:docs heroku-db3 to view documentation
+`))
     })
   })
 })

--- a/test/commands/addons/info.js
+++ b/test/commands/addons/info.js
@@ -32,6 +32,7 @@ Installed at: Invalid Date
 Owning app:   acme-inc-www
 Plan:         heroku-postgresql:hobby-dev
 Price:        free
+State:        created
 `)
       })
     })
@@ -56,6 +57,7 @@ Installed at: Invalid Date
 Owning app:   acme-inc-www
 Plan:         heroku-postgresql:hobby-dev
 Price:        free
+State:        created
 `)
       })
     })
@@ -83,6 +85,7 @@ Installed at: Invalid Date
 Owning app:   acme-inc-www
 Plan:         heroku-postgresql:hobby-dev
 Price:        free
+State:        created
 `)
       })
     })

--- a/test/commands/addons/wait.js
+++ b/test/commands/addons/wait.js
@@ -1,0 +1,87 @@
+'use strict'
+/* globals describe context it expect beforeEach afterEach */
+
+let fixtures = require('../../fixtures')
+let cli = require('heroku-cli-util')
+let nock = require('nock')
+let cmd = require('../../../commands/addons/wait')
+let _ = require('lodash')
+const lolex = require('lolex')
+
+let clock
+const expansionHeaders = {'Accept-Expansion': 'addon_service,plan'}
+
+describe('addons:wait', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+    cli.exit.mock()
+    nock.cleanAll()
+    clock = lolex.install()
+    clock.setTimeout = function (fn, timeout) { fn() }
+  })
+
+  afterEach(function () {
+    clock.uninstall()
+  })
+
+  context('waiting for an individual add-on', function () {
+    context('when the add-on is provisioned', function () {
+      beforeEach(function () {
+        nock('https://api.heroku.com', {reqheaders: expansionHeaders})
+          .get('/apps/example/addons/www-db')
+          .reply(200, fixtures.addons['www-db']) // provisioned
+      })
+
+      it('prints output indicating that it is done', function () {
+        return cmd.run({flags: {}, args: {addon: 'www-db'}})
+          .then(() => expect(cli.stdout, 'to equal', ''))
+          .then(() => expect(cli.stderr, 'to equal', 'Done! www-db is provisioned'))
+      })
+    })
+    context('for an add-on that is still provisioning', function () {
+      it('waits until the add-on is provisioned, then shows config vars', function () {
+        // Call to resolve the add-on:
+        let resolverResponse = nock('https://api.heroku.com')
+          .get('/addons/www-redis')
+          .reply(200, fixtures.addons['www-redis']) // provisioning
+
+        let provisioningResponse = nock('https://api.heroku.com', {reqheaders: expansionHeaders})
+          .get('/apps/acme-inc-www/addons/www-redis')
+          .reply(200, fixtures.addons['www-redis']) // provisioning
+
+        let provisionedAddon = _.clone(fixtures.addons['www-redis'])
+        provisionedAddon.state = 'provisioned'
+        provisionedAddon.config_vars = ['REDIS_URL']
+
+        let provisionedResponse = nock('https://api.heroku.com', {reqheaders: expansionHeaders})
+          .get('/apps/acme-inc-www/addons/www-redis')
+          .reply(200, provisionedAddon)
+
+        return cmd.run({args: {addon: 'www-redis'}, flags: {'wait-interval': '1'}})
+          .then(() => resolverResponse.done())
+          .then(() => provisioningResponse.done())
+          .then(() => provisionedResponse.done())
+          .then(() => expect(cli.stderr).to.equal('Creating www-redis... done\n'))
+          .then(() => expect(cli.stdout).to.equal('Created www-redis as REDIS_URL\n'))
+      })
+    })
+    context('when add-on transitions to deprovisioned state', () => {
+      it('shows that it failed to provision', function () {
+        nock('https://api.heroku.com')
+          .get('/addons/www-redis')
+          .reply(200, fixtures.addons['www-redis']) // provisioning has started
+
+        let deprovisionedAddon = _.clone(fixtures.addons['www-redis'])
+        deprovisionedAddon.state = 'deprovisioned'
+
+        nock('https://api.heroku.com', {reqheaders: expansionHeaders})
+          .get('/apps/acme-inc-www/addons/www-redis')
+          .reply(200, deprovisionedAddon)
+
+        let cmdPromise = cmd.run({flags: {}, args: {addon: 'www-redis'}})
+
+        expect(cmdPromise, 'to be rejected with', 'The add-on was unable to be created, with status deprovisioned')
+      })
+    })
+  })
+})

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -98,42 +98,48 @@ fixtures.addons = {
     id: '8895ea98-4c7b-11e5-9a16-2cf0ee2c94de',
     name: 'www-db',
     addon_service: fixtures.services['heroku-postgresql'],
-    plan: fixtures.plans['heroku-postgresql:hobby-dev']
+    plan: fixtures.plans['heroku-postgresql:hobby-dev'],
+    state: 'provisioned'
   },
   'www-redis': {
     app: fixtures.apps.www,
     id: '8a836ecc-4c88-11e5-ba7e-2cf0ee2c94de',
     name: 'www-redis',
     addon_service: fixtures.services['heroku-redis'],
-    plan: fixtures.plans['heroku-redis:premium-2']
+    plan: fixtures.plans['heroku-redis:premium-2'],
+    state: 'provisioning'
   },
   'api-redis': {
     app: fixtures.apps.api,
     id: 'fd1d2d74-4c88-11e5-8b63-2cf0ee2c94de',
     name: 'api-redis',
     addon_service: fixtures.services['heroku-redis'],
-    plan: fixtures.plans['heroku-redis:premium-2']
+    plan: fixtures.plans['heroku-redis:premium-2'],
+    state: 'provisioned'
   },
   'dwh-test-db': {
     app: fixtures.apps.dwh,
     id: '87f63372-60f8-11e5-bd19-2cf0ee2c94de',
     name: 'dwh-test-db',
     addon_service: fixtures.services['heroku-postgresql'],
-    plan: fixtures.plans['heroku-postgresql:hobby-dev']
+    plan: fixtures.plans['heroku-postgresql:hobby-dev'],
+    state: 'provisioned'
   },
   'dwh-db': {
     app: fixtures.apps.dwh,
     id: 'e00e794c-60ef-11e5-a8c7-2cf0ee2c94de',
     name: 'dwh-db',
     addon_service: fixtures.services['heroku-postgresql'],
-    plan: fixtures.plans['heroku-postgresql:standard-2']
+    plan: fixtures.plans['heroku-postgresql:standard-2'],
+    state: 'provisioned'
   },
   'dwh-db-2': {
     app: fixtures.apps.dwh,
     id: '10b42dda-60fa-11e5-8567-2cf0ee2c94de',
     name: 'dwh-db-2',
     addon_service: fixtures.services['heroku-postgresql'],
-    plan: fixtures.plans['heroku-postgresql:standard-2']
+    plan: fixtures.plans['heroku-postgresql:standard-2'],
+    state: 'provisioned'
   }
 }
 


### PR DESCRIPTION
This reverts https://github.com/heroku/heroku-cli-addons/pull/48 which was a revert of this functionality. We're past the Dreamfreeze and now we can put this back in the plugin.

Notably, it adds the ability for a `heroku addons:create` command to `--wait` for an async provisioning add-on to finish provisioning, or alternatively, you can wait for a specific add-on with `heroku addons:wait`.