### PR TITLE
Only cache the promise on success & preauth: true

### DIFF
--- a/commands/addons/upgrade.js
+++ b/commands/addons/upgrade.js
@@ -122,7 +122,7 @@ Examples:
   needsAuth: true,
   wantsApp: true,
   args: [{name: 'addon'}, {name: 'plan', optional: true}],
-  run: cli.command(co.wrap(run))
+  run: cli.command({preauth: true}, co.wrap(run))
 }
 
 module.exports = [


### PR DESCRIPTION
@mathias could you review?  We were hitting bugs in upgrade where we were caching the two factor response.  I refactored this so that we only cache the promise if it was successful.  I also added preAuth to upgrade so that the yubikey only has to be entered once.  And I changed the memorization key to be `app|addon` instead of `app-addon` as `app` is allowed to have dashes in it.