### PR TITLE
Refactor getAppAddonAttachment to throw errors

### DIFF
--- a/commands/addons/open.js
+++ b/commands/addons/open.js
@@ -67,11 +67,7 @@ function * run (ctx, api) {
 
   let attachment = yield resolve.attachment(api, ctx.app, ctx.args.addon)
   .catch(function (err) {
-    if (err.statusCode === 404) {
-      return null
-    } else {
-      throw err
-    }
+    if (err.statusCode !== 404) throw err
   })
 
   let webUrl

--- a/commands/addons/open.js
+++ b/commands/addons/open.js
@@ -66,8 +66,15 @@ function * run (ctx, api) {
   if (process.env.HEROKU_SUDO) return sudo(ctx, api)
 
   let attachment = yield resolve.attachment(api, ctx.app, ctx.args.addon)
-  let webUrl
+  .catch(function (err) {
+    if (err.statusCode === 404) {
+      return null
+    } else {
+      throw err
+    }
+  })
 
+  let webUrl
   if (attachment) {
     webUrl = attachment.web_url
   } else {

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -57,8 +57,8 @@ function AmbiguousError (objects) {
   this.name = this.constructor.name
 
   this.statusCode = 422
-  this.body = {'id': 'multiple_matches'}
   this.message = `Ambiguous identifier; multiple matching addons found: ${objects.map((object) => object.name).join(', ')}.`
+  this.body = {'id': 'multiple_matches', 'message': this.message}
 }
 
 exports.attachment = function (heroku, app, id, headers) {

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -57,6 +57,7 @@ function AmbiguousError (objects) {
   this.name = this.constructor.name
 
   this.statusCode = 422
+  this.body = {'id': 'multiple_matches'}
   this.message = `Ambiguous identifier; multiple matching addons found: ${objects.map((object) => object.name).join(', ')}.`
 }
 

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -42,6 +42,24 @@ const memoizePromise = function (func, resolver) {
 
 exports.addon = memoizePromise(addonResolver, (_, app, id) => `${app}|${id}`)
 
+function NotFound () {
+  Error.call(this)
+  Error.captureStackTrace(this, this.constructor)
+  this.name = this.constructor.name
+
+  this.statusCode = 404
+  this.message = 'Couldn\'t find that addon.'
+}
+
+function AmbiguousError (objects) {
+  Error.call(this)
+  Error.captureStackTrace(this, this.constructor)
+  this.name = this.constructor.name
+
+  this.statusCode = 422
+  this.message = `Ambiguous identifier; multiple matching addons found: ${objects.map((object) => object.name).join(', ')}.`
+}
+
 exports.attachment = function (heroku, app, id, headers) {
   headers = headers || {}
 
@@ -58,7 +76,16 @@ exports.attachment = function (heroku, app, id, headers) {
 
   function getAppAddonAttachment (addon, app) {
     return heroku.get(`/addons/${encodeURIComponent(addon.id)}/addon-attachments`, {headers})
-      .then((attachments) => attachments.find((att) => att.app.name === app))
+      .then(function (attachments) {
+        const matches = attachments.filter((att) => att.app.name === app)
+        if (matches.length === 0) {
+          throw new NotFound()
+        } else if (matches.length === 1) {
+          return matches[0]
+        } else {
+          throw new AmbiguousError(matches)
+        }
+      })
   }
 
   // first check to see if there is an attachment matching this app/id combo
@@ -69,9 +96,11 @@ exports.attachment = function (heroku, app, id, headers) {
       // If we were passed an add-on slug, there still could be an attachment
       // to the context app. Try to find and use it so `context_app` is set
       // correctly in the SSO payload.
-      else {
+      else if (app) {
         return exports.addon(heroku, app, id)
         .then((addon) => getAppAddonAttachment(addon, app))
+      } else {
+        throw new NotFound()
       }
     })
 }

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -62,12 +62,13 @@ function AmbiguousError (objects) {
 }
 
 const singularize = function (matches) {
-  if (matches.length === 0) {
-    throw new NotFound()
-  } else if (matches.length === 1) {
-    return matches[0]
-  } else {
-    throw new AmbiguousError(matches)
+  switch (matches.length) {
+    case 0:
+      throw new NotFound()
+    case 1:
+      return matches[0]
+    default:
+      throw new AmbiguousError(matches)
   }
 }
 

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -61,6 +61,16 @@ function AmbiguousError (objects) {
   this.body = {'id': 'multiple_matches', 'message': this.message}
 }
 
+const singularize = function (matches) {
+  if (matches.length === 0) {
+    throw new NotFound()
+  } else if (matches.length === 1) {
+    return matches[0]
+  } else {
+    throw new AmbiguousError(matches)
+  }
+}
+
 exports.attachment = function (heroku, app, id, headers) {
   headers = headers || {}
 
@@ -78,14 +88,7 @@ exports.attachment = function (heroku, app, id, headers) {
   function getAppAddonAttachment (addon, app) {
     return heroku.get(`/addons/${encodeURIComponent(addon.id)}/addon-attachments`, {headers})
       .then(function (attachments) {
-        const matches = attachments.filter((att) => att.app.name === app)
-        if (matches.length === 0) {
-          throw new NotFound()
-        } else if (matches.length === 1) {
-          return matches[0]
-        } else {
-          throw new AmbiguousError(matches)
-        }
+        return singularize(attachments.filter((att) => att.app.name === app))
       })
   }
 

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -57,7 +57,7 @@ function AmbiguousError (objects) {
   this.name = this.constructor.name
 
   this.statusCode = 422
-  this.message = `Ambiguous identifier; multiple matching addons found: ${objects.map((object) => object.name).join(', ')}.`
+  this.message = `Ambiguous identifier; multiple matching add-ons found: ${objects.map((object) => object.name).join(', ')}.`
   this.body = {'id': 'multiple_matches', 'message': this.message}
 }
 

--- a/test/lib/resolve.js
+++ b/test/lib/resolve.js
@@ -214,7 +214,7 @@ describe('resolve', () => {
 
       return resolve.attachment(new Heroku(), 'myapp', 'myattachment-5')
         .then(() => { throw new Error('unreachable') })
-        .catch((err) => expect(err, 'to satisfy', {message: 'Ambiguous identifier; multiple matching addons found: some-random-name-1, some-random-name-2.'}))
+        .catch((err) => expect(err, 'to satisfy', {message: 'Ambiguous identifier; multiple matching add-ons found: some-random-name-1, some-random-name-2.'}))
         .then(() => api.done())
         .then(() => appAddon.done())
         .then(() => appAttachment.done())

--- a/test/lib/resolve.js
+++ b/test/lib/resolve.js
@@ -153,5 +153,71 @@ describe('resolve', () => {
         .catch((err) => expect(err, 'to satisfy', {statusCode: 401}))
         .then(() => api.done())
     })
+
+    it('falls back to searching by addon', () => {
+      let api = nock('https://api.heroku.com:443')
+        .get('/apps/myapp/addon-attachments/myattachment-3').reply(404)
+
+      let appAddon = nock('https://api.heroku.com:443')
+        .get('/apps/myapp/addons/myattachment-3').reply(200, {id: '1e97e8ba-fd24-48a4-8118-eaf287eb7a0f', name: 'myaddon-3'})
+
+      let appAttachment = nock('https://api.heroku.com:443')
+        .get('/addons/1e97e8ba-fd24-48a4-8118-eaf287eb7a0f/addon-attachments').reply(200, [{app: {name: 'myapp'}, name: 'some-random-name'}])
+
+      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-3')
+        .then((addon) => expect(addon, 'to satisfy', {name: 'some-random-name'}))
+        .then(() => api.done())
+        .then(() => appAddon.done())
+        .then(() => appAttachment.done())
+    })
+
+    it('throws an error when not found', () => {
+      let api = nock('https://api.heroku.com:443')
+        .get('/apps/myapp/addon-attachments/myattachment-4').reply(404)
+
+      let appAddon = nock('https://api.heroku.com:443')
+        .get('/apps/myapp/addons/myattachment-4').reply(200, {id: '1e97e8ba-fd24-48a4-8118-eaf287eb7a0f', name: 'myaddon-4'})
+
+      let appAttachment = nock('https://api.heroku.com:443')
+        .get('/addons/1e97e8ba-fd24-48a4-8118-eaf287eb7a0f/addon-attachments').reply(200, [{app: {name: 'not-myapp'}, name: 'some-random-name'}])
+
+      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-4')
+        .then(() => { throw new Error('unreachable') })
+        .catch((err) => expect(err, 'to satisfy', {message: 'Couldn\'t find that addon.'}))
+        .then(() => api.done())
+        .then(() => appAddon.done())
+        .then(() => appAttachment.done())
+    })
+
+    it('does not fallback and throws error when there is no app', () => {
+      let api = nock('https://api.heroku.com:443')
+        .get('/addon-attachments/myattachment-4').reply(404)
+
+      return resolve.attachment(new Heroku(), null, 'myattachment-4')
+        .then(() => { throw new Error('unreachable') })
+        .catch((err) => expect(err, 'to satisfy', {message: 'Couldn\'t find that addon.'}))
+        .then(() => api.done())
+    })
+
+    it('throws an error when ambiguous', () => {
+      let api = nock('https://api.heroku.com:443')
+        .get('/apps/myapp/addon-attachments/myattachment-5').reply(404)
+
+      let appAddon = nock('https://api.heroku.com:443')
+        .get('/apps/myapp/addons/myattachment-5').reply(200, {id: '1e97e8ba-fd24-48a4-8118-eaf287eb7a0f', name: 'myaddon-5'})
+
+      let appAttachment = nock('https://api.heroku.com:443')
+        .get('/addons/1e97e8ba-fd24-48a4-8118-eaf287eb7a0f/addon-attachments').reply(200, [
+          {app: {name: 'myapp'}, name: 'some-random-name-1'},
+          {app: {name: 'myapp'}, name: 'some-random-name-2'}
+        ])
+
+      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-5')
+        .then(() => { throw new Error('unreachable') })
+        .catch((err) => expect(err, 'to satisfy', {message: 'Ambiguous identifier; multiple matching addons found: some-random-name-1, some-random-name-2.'}))
+        .then(() => api.done())
+        .then(() => appAddon.done())
+        .then(() => appAttachment.done())
+    })
   })
 })


### PR DESCRIPTION
@dickeyxxx could you review?  It changes the behavior slightly for attachment resolving.  If there are ambiguous matches in `getAppAddonAttachment` we now throw an error.