### PR TITLE
Use new resolver endpoints

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -2,15 +2,37 @@
 
 const memoize = require('lodash.memoize')
 
+const addActionsHeader = function (headers) {
+  return Object.assign({'Accept': 'application/vnd.heroku+json; version=3.actions'}, headers || {})
+}
+
 const addonResolver = function (heroku, app, id, options = {}) {
-  const headers = options.headers || {}
+  const headers = addActionsHeader(options.headers)
+
   let getAddon = function (id) {
-    return heroku.get(`/addons/${encodeURIComponent(id)}`, {headers})
+    return heroku.post('/actions/addons/resolve', {
+      'headers': headers,
+      'body': {'app': null, 'addon': id}
+    })
+    .then((addons) => singularize(addons))
   }
 
-  if (!app || id.indexOf('::') !== -1) return getAddon(id)
-  return heroku.get(`/apps/${app}/addons/${encodeURIComponent(id)}`, {headers})
-    .catch(function (err) { if (err.statusCode === 404) return getAddon(id); else throw err })
+  if (!app || id.indexOf('::') !== -1) {
+    return getAddon(id)
+  } else {
+    return heroku.post('/actions/addons/resolve', {
+      'headers': headers,
+      'body': {'app': app, 'addon': id}
+    })
+    .then((addons) => singularize(addons))
+    .catch(function (err) {
+      if (err.statusCode === 404) {
+        return getAddon(id)
+      } else {
+        throw err
+      }
+    })
+  }
 }
 
 /**
@@ -73,16 +95,18 @@ const singularize = function (matches) {
 }
 
 exports.attachment = function (heroku, app, id, options = {}) {
-  const headers = options.headers || {}
+  const headers = addActionsHeader(options.headers)
 
   function getAttachment (id) {
-    return heroku.get(`/addon-attachments/${encodeURIComponent(id)}`, {headers})
+    return heroku.post('/actions/addon-attachments/resolve', {'headers': headers, 'body': {'app': null, 'addon_attachment': id}})
+      .then((attachments) => singularize(attachments))
       .catch(function (err) { if (err.statusCode !== 404) throw err })
   }
 
   function getAppAttachment (app, id) {
     if (!app || id.indexOf('::') !== -1) return getAttachment(id)
-    return heroku.get(`/apps/${app}/addon-attachments/${encodeURIComponent(id)}`, {headers})
+    return heroku.post('/actions/addon-attachments/resolve', {'headers': headers, 'body': {'app': app, 'addon_attachment': id}})
+      .then((attachments) => singularize(attachments))
       .catch(function (err) { if (err.statusCode !== 404) throw err })
   }
 

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -107,16 +107,20 @@ const appAttachment = function (heroku, app, id, options = {}) {
 
 exports.appAttachment = appAttachment
 
-const filter = function (attachment, app, addonService) {
-  if (attachment.app.name !== app) {
-    return false
-  }
+const filter = function (app, addonService) {
+  return attachments => {
+    return attachments.filter(attachment => {
+      if (attachment.app.name !== app) {
+        return false
+      }
 
-  if (addonService && attachment.addon_service.name !== addonService) {
-    return false
-  }
+      if (addonService && attachment.addon_service.name !== addonService) {
+        return false
+      }
 
-  return true
+      return true
+    })
+  }
 }
 
 exports.attachment = function (heroku, app, id, options = {}) {
@@ -131,9 +135,8 @@ exports.attachment = function (heroku, app, id, options = {}) {
 
   function getAppAddonAttachment (addon, app) {
     return heroku.get(`/addons/${encodeURIComponent(addon.id)}/addon-attachments`, {headers})
-      .then(function (attachments) {
-        return singularize(attachments.filter((att) => filter(att, app, options.addon_service)))
-      })
+      .then(filter(app, options.addon_service))
+      .then(singularize)
   }
 
   let promise

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -10,7 +10,7 @@ const appAddon = function (heroku, app, id, options = {}) {
   const headers = addActionsHeader(options.headers)
   return heroku.post('/actions/addons/resolve', {
     'headers': headers,
-    'body': {'app': app, 'addon': id}
+    'body': {'app': app, 'addon': id, 'addon_service': options.addon_service || null}
   })
   .then((addons) => singularize(addons))
 }
@@ -23,7 +23,7 @@ const addonResolver = function (heroku, app, id, options = {}) {
   let getAddon = function (id) {
     return heroku.post('/actions/addons/resolve', {
       'headers': headers,
-      'body': {'app': null, 'addon': id}
+      'body': {'app': null, 'addon': id, 'addon_service': options.addon_service || null}
     })
     .then((addons) => singularize(addons))
   }
@@ -69,7 +69,7 @@ const memoizePromise = function (func, resolver) {
   return memoized
 }
 
-exports.addon = memoizePromise(addonResolver, (_, app, id) => `${app}|${id}`)
+exports.addon = memoizePromise(addonResolver, (_, app, id, options = {}) => `${app}|${id}|${options.addon_service}`)
 
 function NotFound () {
   Error.call(this)
@@ -103,25 +103,39 @@ const singularize = function (matches) {
 
 const appAttachment = function (heroku, app, id, options = {}) {
   const headers = addActionsHeader(options.headers)
-  return heroku.post('/actions/addon-attachments/resolve', {'headers': headers, 'body': {'app': app, 'addon_attachment': id}})
-    .then((attachments) => singularize(attachments))
+  return heroku.post('/actions/addon-attachments/resolve', {
+    'headers': headers, 'body': {'app': app, 'addon_attachment': id, 'addon_service': options.addon_service || null}
+  }).then((attachments) => singularize(attachments))
 }
 
 exports.appAttachment = appAttachment
+
+const filter = function (attachment, app, addonService) {
+  if (attachment.app.name !== app) {
+    return false
+  }
+
+  if (addonService && attachment.addon_service.name !== addonService) {
+    return false
+  }
+
+  return true
+}
 
 exports.attachment = function (heroku, app, id, options = {}) {
   const headers = addActionsHeader(options.headers)
 
   function getAttachment (id) {
-    return heroku.post('/actions/addon-attachments/resolve', {'headers': headers, 'body': {'app': null, 'addon_attachment': id}})
-      .then((attachments) => singularize(attachments))
+    return heroku.post('/actions/addon-attachments/resolve', {
+      'headers': headers, 'body': {'app': null, 'addon_attachment': id, 'addon_service': options.addon_service || null}
+    }).then((attachments) => singularize(attachments))
       .catch(function (err) { if (err.statusCode !== 404) throw err })
   }
 
   function getAppAddonAttachment (addon, app) {
     return heroku.get(`/addons/${encodeURIComponent(addon.id)}/addon-attachments`, {headers})
       .then(function (attachments) {
-        return singularize(attachments.filter((att) => att.app.name === app))
+        return singularize(attachments.filter((att) => filter(att, app, options.addon_service)))
       })
   }
 
@@ -142,7 +156,7 @@ exports.attachment = function (heroku, app, id, options = {}) {
       // to the context app. Try to find and use it so `context_app` is set
       // correctly in the SSO payload.
       else if (app) {
-        return exports.addon(heroku, app, id)
+        return exports.addon(heroku, app, id, options)
         .then((addon) => getAppAddonAttachment(addon, app))
       } else {
         throw new NotFound()

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -33,11 +33,8 @@ const addonResolver = function (heroku, app, id, options = {}) {
   } else {
     return appAddon(heroku, app, id, options)
     .catch(function (err) {
-      if (err.statusCode === 404) {
-        return getAddon(id)
-      } else {
-        throw err
-      }
+      if (err.statusCode === 404) return getAddon(id)
+      throw err
     })
   }
 }

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -6,6 +6,17 @@ const addActionsHeader = function (headers) {
   return Object.assign({'Accept': 'application/vnd.heroku+json; version=3.actions'}, headers || {})
 }
 
+const appAddon = function (heroku, app, id, options = {}) {
+  const headers = addActionsHeader(options.headers)
+  return heroku.post('/actions/addons/resolve', {
+    'headers': headers,
+    'body': {'app': app, 'addon': id}
+  })
+  .then((addons) => singularize(addons))
+}
+
+exports.appAddon = appAddon
+
 const addonResolver = function (heroku, app, id, options = {}) {
   const headers = addActionsHeader(options.headers)
 
@@ -20,11 +31,7 @@ const addonResolver = function (heroku, app, id, options = {}) {
   if (!app || id.indexOf('::') !== -1) {
     return getAddon(id)
   } else {
-    return heroku.post('/actions/addons/resolve', {
-      'headers': headers,
-      'body': {'app': app, 'addon': id}
-    })
-    .then((addons) => singularize(addons))
+    return appAddon(heroku, app, id, options)
     .catch(function (err) {
       if (err.statusCode === 404) {
         return getAddon(id)
@@ -94,18 +101,19 @@ const singularize = function (matches) {
   }
 }
 
+const appAttachment = function (heroku, app, id, options = {}) {
+  const headers = addActionsHeader(options.headers)
+  return heroku.post('/actions/addon-attachments/resolve', {'headers': headers, 'body': {'app': app, 'addon_attachment': id}})
+    .then((attachments) => singularize(attachments))
+}
+
+exports.appAttachment = appAttachment
+
 exports.attachment = function (heroku, app, id, options = {}) {
   const headers = addActionsHeader(options.headers)
 
   function getAttachment (id) {
     return heroku.post('/actions/addon-attachments/resolve', {'headers': headers, 'body': {'app': null, 'addon_attachment': id}})
-      .then((attachments) => singularize(attachments))
-      .catch(function (err) { if (err.statusCode !== 404) throw err })
-  }
-
-  function getAppAttachment (app, id) {
-    if (!app || id.indexOf('::') !== -1) return getAttachment(id)
-    return heroku.post('/actions/addon-attachments/resolve', {'headers': headers, 'body': {'app': app, 'addon_attachment': id}})
       .then((attachments) => singularize(attachments))
       .catch(function (err) { if (err.statusCode !== 404) throw err })
   }
@@ -117,8 +125,16 @@ exports.attachment = function (heroku, app, id, options = {}) {
       })
   }
 
+  let promise
+  if (!app || id.indexOf('::') !== -1) {
+    promise = getAttachment(id)
+  } else {
+    promise = appAttachment(heroku, app, id, options)
+    .catch(function (err) { if (err.statusCode !== 404) throw err })
+  }
+
   // first check to see if there is an attachment matching this app/id combo
-  return getAppAttachment(app, id)
+  return promise
     // if no attachment, look up an add-on that matches the id
     .then((attachment) => {
       if (attachment) return attachment

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -12,7 +12,7 @@ const appAddon = function (heroku, app, id, options = {}) {
     'headers': headers,
     'body': {'app': app, 'addon': id, 'addon_service': options.addon_service}
   })
-  .then((addons) => singularize(addons))
+  .then(singularize)
 }
 
 exports.appAddon = appAddon
@@ -25,7 +25,7 @@ const addonResolver = function (heroku, app, id, options = {}) {
       'headers': headers,
       'body': {'app': null, 'addon': id, 'addon_service': options.addon_service}
     })
-    .then((addons) => singularize(addons))
+    .then(singularize)
   }
 
   if (!app || id.includes('::')) {
@@ -102,7 +102,7 @@ const appAttachment = function (heroku, app, id, options = {}) {
   const headers = addActionsHeader(options.headers)
   return heroku.post('/actions/addon-attachments/resolve', {
     'headers': headers, 'body': {'app': app, 'addon_attachment': id, 'addon_service': options.addon_service}
-  }).then((attachments) => singularize(attachments))
+  }).then(singularize)
 }
 
 exports.appAttachment = appAttachment
@@ -125,7 +125,7 @@ exports.attachment = function (heroku, app, id, options = {}) {
   function getAttachment (id) {
     return heroku.post('/actions/addon-attachments/resolve', {
       'headers': headers, 'body': {'app': null, 'addon_attachment': id, 'addon_service': options.addon_service}
-    }).then((attachments) => singularize(attachments))
+    }).then(singularize)
       .catch(function (err) { if (err.statusCode !== 404) throw err })
   }
 

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -10,7 +10,7 @@ const appAddon = function (heroku, app, id, options = {}) {
   const headers = addActionsHeader(options.headers)
   return heroku.post('/actions/addons/resolve', {
     'headers': headers,
-    'body': {'app': app, 'addon': id, 'addon_service': options.addon_service || null}
+    'body': {'app': app, 'addon': id, 'addon_service': options.addon_service}
   })
   .then((addons) => singularize(addons))
 }
@@ -23,7 +23,7 @@ const addonResolver = function (heroku, app, id, options = {}) {
   let getAddon = function (id) {
     return heroku.post('/actions/addons/resolve', {
       'headers': headers,
-      'body': {'app': null, 'addon': id, 'addon_service': options.addon_service || null}
+      'body': {'app': null, 'addon': id, 'addon_service': options.addon_service}
     })
     .then((addons) => singularize(addons))
   }
@@ -104,7 +104,7 @@ const singularize = function (matches) {
 const appAttachment = function (heroku, app, id, options = {}) {
   const headers = addActionsHeader(options.headers)
   return heroku.post('/actions/addon-attachments/resolve', {
-    'headers': headers, 'body': {'app': app, 'addon_attachment': id, 'addon_service': options.addon_service || null}
+    'headers': headers, 'body': {'app': app, 'addon_attachment': id, 'addon_service': options.addon_service}
   }).then((attachments) => singularize(attachments))
 }
 
@@ -127,7 +127,7 @@ exports.attachment = function (heroku, app, id, options = {}) {
 
   function getAttachment (id) {
     return heroku.post('/actions/addon-attachments/resolve', {
-      'headers': headers, 'body': {'app': null, 'addon_attachment': id, 'addon_service': options.addon_service || null}
+      'headers': headers, 'body': {'app': null, 'addon_attachment': id, 'addon_service': options.addon_service}
     }).then((attachments) => singularize(attachments))
       .catch(function (err) { if (err.statusCode !== 404) throw err })
   }

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -28,7 +28,7 @@ const addonResolver = function (heroku, app, id, options = {}) {
     .then((addons) => singularize(addons))
   }
 
-  if (!app || id.indexOf('::') !== -1) {
+  if (!app || id.includes('::')) {
     return getAddon(id)
   } else {
     return appAddon(heroku, app, id, options)
@@ -140,7 +140,7 @@ exports.attachment = function (heroku, app, id, options = {}) {
   }
 
   let promise
-  if (!app || id.indexOf('::') !== -1) {
+  if (!app || id.includes('::')) {
     promise = getAttachment(id)
   } else {
     promise = appAttachment(heroku, app, id, options)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
+    "lolex": "1.5.1",
     "mocha": "3.0.2",
     "nock": "8.0.0",
     "nyc": "7.1.0",

--- a/test/commands/addons/destroy.js
+++ b/test/commands/addons/destroy.js
@@ -12,7 +12,7 @@ describe('addons:destroy', () => {
     let addon = {id: 201, name: 'db3-swiftly-123', addon_service: {name: 'heroku-db3'}, app: {name: 'myapp', id: 101}}
 
     let api = nock('https://api.heroku.com:443')
-      .get('/addons/heroku-db3').reply(200, addon)
+      .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'heroku-db3'}).reply(200, [addon])
       .delete('/apps/101/addons/201', {force: false})
       .reply(200, {plan: {price: {cents: 0}}, provision_message: 'provision msg'})
 

--- a/test/commands/addons/docs.js
+++ b/test/commands/addons/docs.js
@@ -21,8 +21,8 @@ describe('addons:docs', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/addon-services/my-attachment-1111')
       .reply(404)
-      .get('/addons/my-attachment-1111')
-      .reply(200, {addon_service: {name: 'slowdb'}})
+      .post('/actions/addons/resolve', {'addon': 'my-attachment-1111'})
+      .reply(200, [{addon_service: {name: 'slowdb'}}])
 
     return cmd.run({args: {addon: 'my-attachment-1111'}, flags: {'show-url': true}})
       .then(() => expect(cli.stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n'))
@@ -34,8 +34,8 @@ describe('addons:docs', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/addon-services/my-attachment-1111')
       .reply(404)
-      .get('/apps/myapp/addons/my-attachment-1111')
-      .reply(200, {addon_service: {name: 'slowdb'}})
+      .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'my-attachment-1111'})
+      .reply(200, [{addon_service: {name: 'slowdb'}}])
 
     return cmd.run({app: 'myapp', args: {addon: 'my-attachment-1111'}, flags: {'show-url': true}})
       .then(() => expect(cli.stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n'))

--- a/test/commands/addons/info.js
+++ b/test/commands/addons/info.js
@@ -16,8 +16,8 @@ describe('addons:info', function () {
   context('with add-ons', function () {
     beforeEach(function () {
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
-        .get('/addons/www-db')
-        .reply(200, fixtures.addons['www-db'])
+        .post('/actions/addons/resolve', {'app': null, 'addon': 'www-db'})
+        .reply(200, [fixtures.addons['www-db']])
       nock('https://api.heroku.com')
         .get(`/addons/${fixtures.addons['www-db']['id']}/addon-attachments`)
         .reply(200, [fixtures.attachments['acme-inc-www::DATABASE']])
@@ -41,8 +41,8 @@ State:        created
   context('with app add-ons', function () {
     beforeEach(function () {
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
-        .get('/apps/example/addons/www-db')
-        .reply(200, fixtures.addons['www-db'])
+        .post('/actions/addons/resolve', {'app': 'example', 'addon': 'www-db'})
+        .reply(200, [fixtures.addons['www-db']])
       nock('https://api.heroku.com')
         .get(`/addons/${fixtures.addons['www-db']['id']}/addon-attachments`)
         .reply(200, [fixtures.attachments['acme-inc-www::DATABASE']])

--- a/test/commands/addons/open.js
+++ b/test/commands/addons/open.js
@@ -11,8 +11,8 @@ describe('addons:open', function () {
   it('only prints the URL when --show-url passed', function () {
     let api = nock('https://api.heroku.com:443')
 
-    api.get('/apps/myapp/addons/db2')
-      .reply(200, {id: 'db2', web_url: 'http://db2'})
+    api.post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'db2'})
+      .reply(200, [{id: 'db2', web_url: 'http://db2'}])
 
     api.get('/addons/db2/addon-attachments')
       .reply(200, [])
@@ -25,8 +25,8 @@ describe('addons:open', function () {
   it('opens the addon dashboard in a browser by default', function () {
     let api = nock('https://api.heroku.com:443')
 
-    api.get('/apps/myapp/addons/slowdb')
-      .reply(200, {id: 'slowdb', web_url: 'http://slowdb'})
+    api.post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'slowdb'})
+      .reply(200, [{id: 'slowdb', web_url: 'http://slowdb'}])
 
     api.get('/addons/slowdb/addon-attachments')
       .reply(200, [])
@@ -40,14 +40,14 @@ describe('addons:open', function () {
   it('opens an attached addon, by slug, with the correct `context_app`', function () {
     let api = nock('https://api.heroku.com:443')
 
-    api.get('/apps/myapp-2/addon-attachments/slowdb')
+    api.post('/actions/addon-attachments/resolve', {'app': 'myapp-2', 'addon_attachment': 'slowdb'})
       .reply(404)
 
-    api.get('/apps/myapp-2/addons/slowdb')
+    api.post('/actions/addons/resolve', {'app': 'myapp-2', 'addon': 'slowdb'})
       .reply(404)
 
-    api.get('/addons/slowdb')
-      .reply(200, {id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b', web_url: 'http://myapp-slowdb'})
+    api.post('/actions/addons/resolve', {'app': null, 'addon': 'slowdb'})
+      .reply(200, [{id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b', web_url: 'http://myapp-slowdb'}])
 
     api.get('/addons/c7c9cf20-ec87-11e5-aea4-0002a5d5c51b/addon-attachments')
       .reply(200, [

--- a/test/commands/addons/upgrade.js
+++ b/test/commands/addons/upgrade.js
@@ -11,7 +11,7 @@ describe('addons:upgrade', () => {
     let addon = {name: 'kafka-swiftly-123', addon_service: {name: 'heroku-kafka'}, app: {name: 'myapp'}, plan: {name: 'premium-0'}}
 
     let api = nock('https://api.heroku.com:443')
-      .get('/addons/heroku-kafka').reply(200, addon)
+      .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'heroku-kafka'}).reply(200, [addon])
       .patch('/apps/myapp/addons/kafka-swiftly-123', {plan: {name: 'heroku-kafka:hobby'}})
       .reply(200, {plan: {price: {cents: 0}}, provision_message: 'provision msg'})
     return cmd.run({app: 'myapp', args: {addon: 'heroku-kafka', plan: 'heroku-kafka:hobby'}})
@@ -24,7 +24,7 @@ describe('addons:upgrade', () => {
     let addon = {name: 'postgresql-swiftly-123', addon_service: {name: 'heroku-postgresql'}, app: {name: 'myapp'}, plan: {name: 'premium-0'}}
 
     let api = nock('https://api.heroku.com:443')
-      .get('/addons/heroku-postgresql').reply(200, addon)
+      .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'heroku-postgresql'}).reply(200, [addon])
       .patch('/apps/myapp/addons/postgresql-swiftly-123', {plan: {name: 'heroku-postgresql:hobby'}})
       .reply(200, {plan: {price: {cents: 0}}})
     return cmd.run({app: 'myapp', args: {addon: 'heroku-postgresql:hobby'}})
@@ -42,7 +42,7 @@ describe('addons:upgrade', () => {
     let addon = {name: 'db1-swiftly-123', addon_service: {name: 'heroku-db1'}, app: {name: 'myapp'}, plan: {name: 'premium-0'}}
 
     let api = nock('https://api.heroku.com:443')
-      .get('/addons/heroku-db1').reply(200, addon)
+      .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'heroku-db1'}).reply(200, [addon])
       .get('/addon-services/heroku-db1/plans').reply(200, [
         {name: 'heroku-db1:free'},
         {name: 'heroku-db1:premium-0'}
@@ -64,7 +64,8 @@ https://devcenter.heroku.com/articles/managing-add-ons`)
 
   it('handles multiple add-ons', () => {
     let api = nock('https://api.heroku.com:443')
-      .get('/addons/heroku-redis').reply(422, {id: 'multiple_matches', message: 'Ambiguous identifier; multiple matching add-ons found: redis-defined-2951, redis-rigid-2920.'})
+      .post('/actions/addons/resolve', {'app': null, 'addon': 'heroku-redis'})
+      .reply(200, [{'name': 'db1-swiftly-123'}, {'name': 'db1-swiftly-456'}])
     return expect(cmd.run({args: {addon: 'heroku-redis:invalid'}}),
       'to be rejected with', /multiple matching add-ons found/)
       .then(() => api.done())

--- a/test/commands/addons/wait.js
+++ b/test/commands/addons/wait.js
@@ -28,8 +28,8 @@ describe('addons:wait', function () {
     context('when the add-on is provisioned', function () {
       beforeEach(function () {
         nock('https://api.heroku.com', {reqheaders: expansionHeaders})
-          .get('/apps/example/addons/www-db')
-          .reply(200, fixtures.addons['www-db']) // provisioned
+          .post('/actions/addons/resolve', {'app': null, 'addon': 'www-db'})
+          .reply(200, [fixtures.addons['www-db']]) // provisioned
       })
 
       it('prints output indicating that it is done', function () {
@@ -42,8 +42,8 @@ describe('addons:wait', function () {
       it('waits until the add-on is provisioned, then shows config vars', function () {
         // Call to resolve the add-on:
         let resolverResponse = nock('https://api.heroku.com')
-          .get('/addons/www-redis')
-          .reply(200, fixtures.addons['www-redis']) // provisioning
+          .post('/actions/addons/resolve', {'app': null, 'addon': 'www-redis'})
+          .reply(200, [fixtures.addons['www-redis']]) // provisioning
 
         let provisioningResponse = nock('https://api.heroku.com', {reqheaders: expansionHeaders})
           .get('/apps/acme-inc-www/addons/www-redis')

--- a/test/lib/resolve.js
+++ b/test/lib/resolve.js
@@ -239,10 +239,10 @@ describe('resolve', () => {
 
     it('falls back to searching by addon and ignores addon_service if not passed', () => {
       let api = nock('https://api.heroku.com:443')
-        .post('/actions/addon-attachments/resolve', {'app': 'myapp', 'addon_attachment': 'myattachment-3', 'addon_service': null}).reply(404)
+        .post('/actions/addon-attachments/resolve', {'app': 'myapp', 'addon_attachment': 'myattachment-3'}).reply(404)
 
       let appAddon = nock('https://api.heroku.com:443')
-        .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'myattachment-3', 'addon_service': null}).reply(200, [{id: '1e97e8ba-fd24-48a4-8118-eaf287eb7a0f', name: 'myaddon-3'}])
+        .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'myattachment-3'}).reply(200, [{id: '1e97e8ba-fd24-48a4-8118-eaf287eb7a0f', name: 'myaddon-3'}])
 
       let appAttachment = nock('https://api.heroku.com:443')
         .get('/addons/1e97e8ba-fd24-48a4-8118-eaf287eb7a0f/addon-attachments').reply(200, [{app: {name: 'myapp'}, name: 'some-random-name', addon_service: {name: 'slowdb'}}])


### PR DESCRIPTION
@dickeyxxx could you review, but not merge?  I still have some things to manually test before I am comfortable with this being live.  This swaps in the new resolver endpoints, exposes some methods for `heroku-pg` to use and adds a `addons_service` option to filter the resolver down to just addons of a certain type.