### PR TITLE
Push down headers setting into addonResolver

### DIFF
--- a/commands/addons/info.js
+++ b/commands/addons/info.js
@@ -10,7 +10,7 @@ let style = require('../../lib/util').style
 let run = cli.command({preauth: true}, function (ctx, api) {
   const resolve = require('../../lib/resolve')
   return co(function * () {
-    let addon = yield resolve.addon(api, ctx.app, ctx.args.addon, {'headers': {'Accept-Expansion': 'addon_service,plan'}})
+    let addon = yield resolve.addon(api, ctx.app, ctx.args.addon)
 
     addon.attachments = yield api.request({
       method: 'GET',

--- a/commands/addons/wait.js
+++ b/commands/addons/wait.js
@@ -6,7 +6,7 @@ let waitForAddonProvisioning = require('../../lib/addons_wait')
 
 function * run (ctx, api) {
   const resolve = require('../../lib/resolve')
-  let addon = yield resolve.addon(api, ctx.app, ctx.args.addon, {'headers': {'Accept-Expansion': 'addon_service,plan'}})
+  let addon = yield resolve.addon(api, ctx.app, ctx.args.addon)
 
   let interval = parseInt(ctx.flags['wait-interval'])
   if (!interval || interval < 0) { interval = 5 }

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -73,19 +73,21 @@ const singularize = function (matches) {
 }
 
 exports.attachment = function (heroku, app, id, options = {}) {
+  const headers = {'Accept-Inclusion': 'addon:plan,config_vars'}
+
   function getAttachment (id) {
-    return heroku.get(`/addon-attachments/${encodeURIComponent(id)}`)
+    return heroku.get(`/addon-attachments/${encodeURIComponent(id)}`, {headers})
       .catch(function (err) { if (err.statusCode !== 404) throw err })
   }
 
   function getAppAttachment (app, id) {
     if (!app || id.indexOf('::') !== -1) return getAttachment(id)
-    return heroku.get(`/apps/${app}/addon-attachments/${encodeURIComponent(id)}`)
+    return heroku.get(`/apps/${app}/addon-attachments/${encodeURIComponent(id)}`, {headers})
       .catch(function (err) { if (err.statusCode !== 404) throw err })
   }
 
   function getAppAddonAttachment (addon, app) {
-    return heroku.get(`/addons/${encodeURIComponent(addon.id)}/addon-attachments`)
+    return heroku.get(`/addons/${encodeURIComponent(addon.id)}/addon-attachments`, {headers})
       .then(function (attachments) {
         return singularize(attachments.filter((att) => att.app.name === app))
       })

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -3,7 +3,7 @@
 const memoize = require('lodash.memoize')
 
 const addonResolver = function (heroku, app, id, options = {}) {
-  const headers = options.headers || {}
+  const headers = {'Accept-Expansion': 'addon_service,plan'}
   let getAddon = function (id) {
     return heroku.get(`/addons/${encodeURIComponent(id)}`, {headers})
   }
@@ -73,21 +73,19 @@ const singularize = function (matches) {
 }
 
 exports.attachment = function (heroku, app, id, options = {}) {
-  const headers = options.headers || {}
-
   function getAttachment (id) {
-    return heroku.get(`/addon-attachments/${encodeURIComponent(id)}`, {headers})
+    return heroku.get(`/addon-attachments/${encodeURIComponent(id)}`)
       .catch(function (err) { if (err.statusCode !== 404) throw err })
   }
 
   function getAppAttachment (app, id) {
     if (!app || id.indexOf('::') !== -1) return getAttachment(id)
-    return heroku.get(`/apps/${app}/addon-attachments/${encodeURIComponent(id)}`, {headers})
+    return heroku.get(`/apps/${app}/addon-attachments/${encodeURIComponent(id)}`)
       .catch(function (err) { if (err.statusCode !== 404) throw err })
   }
 
   function getAppAddonAttachment (addon, app) {
-    return heroku.get(`/addons/${encodeURIComponent(addon.id)}/addon-attachments`, {headers})
+    return heroku.get(`/addons/${encodeURIComponent(addon.id)}/addon-attachments`)
       .then(function (attachments) {
         return singularize(attachments.filter((att) => att.app.name === app))
       })


### PR DESCRIPTION
@dickeyxxx could you review?  I am moving the header setting down into the resolver because it gets more complicated when we move to the new resolver and it is easier if I just pass them all the time.