### PR TITLE
Factor out createAddon for use by heroku-fork

### DIFF
--- a/commands/addons/attach.js
+++ b/commands/addons/attach.js
@@ -25,7 +25,7 @@ function * run (context, heroku) {
     )
   }
 
-  let attachment = yield util.trapConfirmationRequired(context, (confirm) => createAttachment(app, context.flags.as, confirm))
+  let attachment = yield util.trapConfirmationRequired(context.app, context.flags.confirm, (confirm) => createAttachment(app, context.flags.as, confirm))
 
   yield cli.action(
     `Setting ${cli.color.attachment(attachment.name)} config vars and restarting ${cli.color.app(app)}`,

--- a/commands/addons/create.js
+++ b/commands/addons/create.js
@@ -2,7 +2,6 @@
 
 const cli = require('heroku-cli-util')
 const co = require('co')
-let waitForAddonProvisioning = require('../../lib/addons_wait')
 
 function parseConfig (args) {
   let config = {}
@@ -31,58 +30,14 @@ function parseConfig (args) {
   return config
 }
 
-function formatConfigVarsMessage (addon) {
-  let configVars = (addon.config_vars || [])
-
-  if (configVars.length > 0) {
-    configVars = configVars.map(c => cli.color.configVar(c)).join(', ')
-    return `Created ${cli.color.addon(addon.name)} as ${configVars}`
-  } else {
-    return `Created ${cli.color.addon(addon.name)}`
-  }
-}
-
 function * run (context, heroku) {
-  const util = require('../../lib/util')
+  let createAddon = require('../../lib/create_addon')
 
   let {app, flags, args} = context
   let {name, as} = flags
-  let plan = {name: args[0]}
   let config = parseConfig(args.slice(1))
 
-  function createAddon (app, config, name, confirm, plan, as) {
-    return cli.action(`Creating ${plan.name} on ${cli.color.app(app)}`,
-      heroku.post(`/apps/${app}/addons`, {
-        body: { config, name, confirm, plan, attachment: {name: as} },
-        headers: {
-          'accept-expansion': 'plan',
-          'x-heroku-legacy-provider-messages': 'true'
-        }
-      }).then(function (addon) {
-        cli.action.done(cli.color.green(util.formatPrice(addon.plan.price)))
-        return addon
-      })
-    )
-  }
-
-  let addon = yield util.trapConfirmationRequired(context.app, context.flags.confirm, (confirm) => (createAddon(app, config, name, confirm, plan, as)))
-
-  if (addon.provision_message) { cli.log(addon.provision_message) }
-
-  if (addon.state === 'provisioning') {
-    if (context.flags.wait) {
-      cli.log(`Waiting for ${cli.color.addon(addon.name)}...`)
-      addon = yield waitForAddonProvisioning(heroku, addon, 5)
-      cli.log(formatConfigVarsMessage(addon))
-    } else {
-      cli.log(`${cli.color.addon(addon.name)} is being created in the background. The app will restart when complete...`)
-      cli.log(`Use ${cli.color.cmd('heroku addons:info ' + addon.name)} to check creation progress`)
-    }
-  } else if (addon.state === 'deprovisioned') {
-    throw new Error(`The add-on was unable to be created, with status ${addon.state}`)
-  } else {
-    cli.log(formatConfigVarsMessage(addon))
-  }
+  let addon = yield createAddon(heroku, app, args[0], context.flags.confirm, context.flags.wait, {config, name, as})
 
   cli.log(`Use ${cli.color.cmd('heroku addons:docs ' + addon.addon_service.name)} to view documentation`)
 }

--- a/commands/addons/create.js
+++ b/commands/addons/create.js
@@ -65,7 +65,7 @@ function * run (context, heroku) {
     )
   }
 
-  let addon = yield util.trapConfirmationRequired(context, (confirm) => (createAddon(app, config, name, confirm, plan, as)))
+  let addon = yield util.trapConfirmationRequired(context.app, context.flags.confirm, (confirm) => (createAddon(app, config, name, confirm, plan, as)))
 
   if (addon.provision_message) { cli.log(addon.provision_message) }
 

--- a/commands/addons/create.js
+++ b/commands/addons/create.js
@@ -72,7 +72,7 @@ function * run (context, heroku) {
   if (addon.state === 'provisioning') {
     if (context.flags.wait) {
       cli.log(`Waiting for ${cli.color.addon(addon.name)}...`)
-      addon = yield waitForAddonProvisioning(context, heroku, addon, 5)
+      addon = yield waitForAddonProvisioning(heroku, addon, 5)
       cli.log(formatConfigVarsMessage(addon))
     } else {
       cli.log(`${cli.color.addon(addon.name)} is being created in the background. The app will restart when complete...`)

--- a/commands/addons/wait.js
+++ b/commands/addons/wait.js
@@ -23,7 +23,7 @@ function * run (ctx, api) {
   if (!interval || interval < 0) { interval = 5 }
 
   for (let addon of addons) {
-    addon = yield waitForAddonProvisioning(ctx, api, addon, interval)
+    addon = yield waitForAddonProvisioning(api, addon, interval)
 
     let configVars = (addon.config_vars || [])
     if (configVars.length > 0) {

--- a/index.js
+++ b/index.js
@@ -24,3 +24,4 @@ exports.commands = flatten([
 ])
 
 exports.resolve = require('./lib/resolve')
+exports.createAddon = require('./lib/create_addon')

--- a/lib/addons_wait.js
+++ b/lib/addons_wait.js
@@ -3,7 +3,7 @@
 const co = require('co')
 const cli = require('heroku-cli-util')
 
-module.exports = function * (context, api, addon, interval) {
+module.exports = function * (api, addon, interval) {
   const wait = require('co-wait')
   const app = addon.app.name
   const addonName = addon.name

--- a/lib/create_addon.js
+++ b/lib/create_addon.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+
+function formatConfigVarsMessage (addon) {
+  let configVars = (addon.config_vars || [])
+
+  if (configVars.length > 0) {
+    configVars = configVars.map(c => cli.color.configVar(c)).join(', ')
+    return `Created ${cli.color.addon(addon.name)} as ${configVars}`
+  } else {
+    return `Created ${cli.color.addon(addon.name)}`
+  }
+}
+
+module.exports = function * (heroku, app, plan, confirm, wait, options) {
+  const util = require('./util')
+  const waitForAddonProvisioning = require('./addons_wait')
+
+  function createAddonRequest (confirm) {
+    let body = {
+      confirm,
+      name: options.name,
+      config: options.config,
+      plan: {name: plan},
+      attachment: {name: options.as}
+    }
+
+    return cli.action(`Creating ${plan} on ${cli.color.app(app)}`,
+      heroku.post(`/apps/${app}/addons`, {
+        body,
+        headers: {
+          'accept-expansion': 'plan',
+          'x-heroku-legacy-provider-messages': 'true'
+        }
+      }).then(function (addon) {
+        cli.action.done(cli.color.green(util.formatPrice(addon.plan.price)))
+        return addon
+      })
+    )
+  }
+
+  let addon = yield util.trapConfirmationRequired(app, confirm, (confirm) => (createAddonRequest(confirm)))
+
+  if (addon.provision_message) { cli.log(addon.provision_message) }
+
+  if (addon.state === 'provisioning') {
+    if (wait) {
+      cli.log(`Waiting for ${cli.color.addon(addon.name)}...`)
+      addon = yield waitForAddonProvisioning(heroku, addon, 5)
+      cli.log(formatConfigVarsMessage(addon))
+    } else {
+      cli.log(`${cli.color.addon(addon.name)} is being created in the background. The app will restart when complete...`)
+      cli.log(`Use ${cli.color.cmd('heroku addons:info ' + addon.name)} to check creation progress`)
+    }
+  } else if (addon.state === 'deprovisioned') {
+    throw new Error(`The add-on was unable to be created, with status ${addon.state}`)
+  } else {
+    cli.log(formatConfigVarsMessage(addon))
+  }
+
+  return addon
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -38,12 +38,12 @@ module.exports = {
     return printf(fmt, price.cents / 100, price.unit)
   },
 
-  trapConfirmationRequired: function * (context, fn) {
-    return yield fn(context.flags.confirm)
+  trapConfirmationRequired: function * (app, confirm, fn) {
+    return yield fn(confirm)
     .catch((err) => {
       if (!err.body || err.body.id !== 'confirmation_required') throw err
-      return cli.confirmApp(context.app, context.flags.confirm, err.body.message)
-        .then(() => fn(context.app))
+      return cli.confirmApp(app, confirm, err.body.message)
+        .then(() => fn(app))
     })
   },
 


### PR DESCRIPTION
@dickeyxxx could you review?  I factored out `createAddon` so that we can reuse in `heroku-fork`.  this is specifically to get the confirmation handling so that `heroku-fork` works well in private spaces when getting `This add-on is not automatically networked with this Private Space.`.  I did not factor out createAttachment at this time because we do not get this confirm when attaching and the only time that I could find when it needed a confirm was on config var overwrite, which does not seem like a concern in this case.