### PR TITLE
Add support for postgres credentials

### DIFF
--- a/commands/addons/attach.js
+++ b/commands/addons/attach.js
@@ -9,23 +9,27 @@ function * run (context, heroku) {
   let app = context.app
   let addon = yield heroku.get(`/addons/${encodeURIComponent(context.args.addon_name)}`)
 
-  function createAttachment (app, as, confirm) {
+  function createAttachment (app, as, confirm, credential) {
+    let body = {
+      name: as,
+      app: {name: app},
+      addon: {name: addon.name},
+      confirm
+    }
+    if (credential) {
+      body.namespace = 'credential:' + credential
+    }
     return cli.action(
-      `Attaching ${cli.color.addon(addon.name)}${as ? ' as ' + cli.color.attachment(as) : ''} to ${cli.color.app(app)}`,
+      `Attaching ${credential ? cli.color.addon(credential) + ' of ' : ''}${cli.color.addon(addon.name)}${as ? ' as ' + cli.color.attachment(as) : ''} to ${cli.color.app(app)}`,
       heroku.request({
         path: '/addon-attachments',
         method: 'POST',
-        body: {
-          name: as,
-          app: {name: app},
-          addon: {name: addon.name},
-          confirm
-        }
+        body: body
       })
     )
   }
 
-  let attachment = yield util.trapConfirmationRequired(context.app, context.flags.confirm, (confirm) => createAttachment(app, context.flags.as, confirm))
+  let attachment = yield util.trapConfirmationRequired(context.app, context.flags.confirm, (confirm) => createAttachment(app, context.flags.as, confirm, context.flags.credential))
 
   yield cli.action(
     `Setting ${cli.color.attachment(attachment.name)} config vars and restarting ${cli.color.app(app)}`,
@@ -48,6 +52,7 @@ module.exports = {
   needsApp: true,
   flags: [
     {name: 'as', description: 'name for add-on attachment', hasValue: true},
+    {name: 'credential', description: 'credential name for scoped access to Heroku Postgres', hasValue: true},
     {name: 'confirm', description: 'overwrite existing add-on attachment with same name', hasValue: true}
   ],
   args: [{name: 'addon_name'}],

--- a/test/commands/addons/attach.js
+++ b/test/commands/addons/attach.js
@@ -67,4 +67,20 @@ Setting foo config vars and restarting myapp... done, v10
 `))
       .then(() => api.done())
   })
+
+  it('attaches in the credential namespace if the credential flag is specified', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/addons/postgres-123')
+      .reply(200, {name: 'postgres-123'})
+      .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'postgres-123'}, namespace: 'credential:hello'})
+      .reply(201, {name: 'POSTGRES_HELLO'})
+      .get('/apps/myapp/releases')
+      .reply(200, [{version: 10}])
+    return cmd.run({app: 'myapp', args: {addon_name: 'postgres-123'}, flags: {credential: 'hello'}})
+      .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => expect(cli.stderr, 'to equal', `Attaching hello of postgres-123 to myapp... done
+Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
+`))
+      .then(() => api.done())
+  })
 })


### PR DESCRIPTION
Postgres credentials will be released soon as a private beta. 
This adds support for the addons side of the commands for that project. 
The `attach` command will return `Not found` when used with a `--credential` flag if the user/database is not within the heroku postgres credentials beta. 