### PR TITLE
Fix ambiguous identifier

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -104,6 +104,7 @@ function AmbiguousError (matches, type) {
 
 const singularize = function (type) {
   return (matches) => {
+    matches = matches.filter(m => !m.hasOwnProperty('namespace') || m.namespace === null)
     switch (matches.length) {
       case 0:
         throw new NotFound()

--- a/test/lib/resolve.js
+++ b/test/lib/resolve.js
@@ -96,6 +96,26 @@ describe('resolve', () => {
         .then(() => { api.done() })
     })
 
+    it('finds the addon with null namespace for an app', () => {
+      let api = nock('https://api.heroku.com:443')
+        .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'myaddon-1'})
+        .reply(200, [{'name': 'myaddon-1', 'namespace': null}, {'name': 'myaddon-1b', 'namespace': 'definitely-not-null'}])
+
+      return resolve.addon(new Heroku(), 'myapp', 'myaddon-1')
+        .then((addon) => expect(addon, 'to satisfy', {name: 'myaddon-1'}))
+        .then(() => api.done())
+    })
+
+    it('finds the addon with no namespace for an app', () => {
+      let api = nock('https://api.heroku.com:443')
+        .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'myaddon-1'})
+        .reply(200, [{'name': 'myaddon-1'}, {'name': 'myaddon-1b', 'namespace': 'definitely-not-null'}])
+
+      return resolve.addon(new Heroku(), 'myapp', 'myaddon-1')
+        .then((addon) => expect(addon, 'to satisfy', {name: 'myaddon-1'}))
+        .then(() => api.done())
+    })
+
     describe('memoization', () => {
       it('memoizes an addon for an app', () => {
         let api = nock('https://api.heroku.com:443')


### PR DESCRIPTION
Only consider null namespaces when resolving an addon; other attachments with non-null namespaces are not an actual addon

See https://trello.com/c/c6VHpmy1/2014-creds-cannot-list-credentials-and-specify-a-database-if-a-database-has-over-two-attachments-for-the-same-app for a more detailed overview of the bug. 

this needs test fixing and a big of manual testing to see if this would break another edge case: @uhoh-itsmaciek any thoughts on whether this could be the correct approach?