### PR TITLE
Attaching default is like not specifying credential

### DIFF
--- a/commands/addons/attach.js
+++ b/commands/addons/attach.js
@@ -16,7 +16,7 @@ function * run (context, heroku) {
       addon: {name: addon.name},
       confirm
     }
-    if (credential) {
+    if (credential && credential !== 'default') {
       body.namespace = 'credential:' + credential
     }
     return cli.action(
@@ -29,7 +29,7 @@ function * run (context, heroku) {
     )
   }
 
-  if (context.flags.credential) {
+  if (context.flags.credential && context.flags.credential !== 'default') {
     let credentialConfig = yield heroku.get(`/addons/${addon.name}/config/credential:${context.flags.credential}`)
     if (credentialConfig.length === 0) {
       throw new Error(`Could not find credential ${context.flags.credential} for database ${addon.name}`)

--- a/test/commands/addons/attach.js
+++ b/test/commands/addons/attach.js
@@ -68,6 +68,22 @@ Setting foo config vars and restarting myapp... done, v10
       .then(() => api.done())
   })
 
+  it('attaches an addon without a namespace if the credential flag is set to default', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/addons/postgres-123')
+      .reply(200, {name: 'postgres-123'})
+      .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'postgres-123'}})
+      .reply(201, {name: 'POSTGRES_HELLO'})
+      .get('/apps/myapp/releases')
+      .reply(200, [{version: 10}])
+    return cmd.run({app: 'myapp', args: {addon_name: 'postgres-123'}, flags: {credential: 'default'}})
+      .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => expect(cli.stderr, 'to equal', `Attaching default of postgres-123 to myapp... done
+Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
+`))
+      .then(() => api.done())
+  })
+
   it('attaches in the credential namespace if the credential flag is specified', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/addons/postgres-123')


### PR DESCRIPTION
Before:

`heroku addons:attach $haiku --credential default -a camille-testing`

` ▸    Could not find credential default for database postgresql-regular-19877`

After:

`heroku addons:attach $haiku --credential default -a camille-testing`

```
Attaching default of postgresql-triangular-53088 to ⬢ camille-testing... done
Setting HEROKU_POSTGRESQL_ROSE config vars and restarting ⬢ camille-testing... done, v4
```
