### PR TITLE
URI encode credential name

### DIFF
--- a/commands/addons/attach.js
+++ b/commands/addons/attach.js
@@ -30,7 +30,7 @@ function * run (context, heroku) {
   }
 
   if (context.flags.credential && context.flags.credential !== 'default') {
-    let credentialConfig = yield heroku.get(`/addons/${addon.name}/config/credential:${context.flags.credential}`)
+    let credentialConfig = yield heroku.get(`/addons/${addon.name}/config/credential:${encodeURIComponent(context.flags.credential)}`)
     if (credentialConfig.length === 0) {
       throw new Error(`Could not find credential ${context.flags.credential} for database ${addon.name}`)
     }


### PR DESCRIPTION
Allow non-ASCII credential names to be attached. 

Context: https://trello.com/c/1P3m1iFx/2096-pg-creds-credentials-with-non-ascii-names-cannot-be-attached. 