### PR TITLE
Use yarn & upgrade to node 9.2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,13 @@
+dependencies:
+  override:
+    - yarn
+  cache_directories:
+    - ~/.cache/yarn
+
 machine:
   node:
-    version: v6.2.0
+    version: v9.2.0
+
 test:
   post:
-    - nyc report --reporter=text-lcov > coverage.lcov && bash <(curl -s https://codecov.io/bash)
+    - ./node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && bash <(curl -s https://codecov.io/bash)

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -68,12 +68,10 @@ const memoizePromise = function (func, resolver) {
 
     const result = func.apply(this, args)
 
-    result.then(function () {
+    return result.then(function () {
       memoized.cache = cache.set(key, result) || cache
-      return arguments
+      return result
     })
-
-    return result
   }
   memoized.cache = new memoize.Cache()
   return memoized

--- a/test/commands/addons.--all.js
+++ b/test/commands/addons.--all.js
@@ -20,10 +20,6 @@ describe('addons --all', function () {
   context('with add-ons', function () {
     beforeEach(function () {
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
-        .matchHeader('Accept-Expansion', function (val) {
-          let vals = val.split(',')
-          return vals.indexOf('addon_service') > -1 && vals.indexOf('plan') > -1
-        })
         .get('/addons')
         .reply(200, addons)
     })

--- a/test/commands/addons/attach.js
+++ b/test/commands/addons/attach.js
@@ -109,10 +109,12 @@ Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
       .get('/addons/postgres-123/config/credential:hello')
       .reply(200, [])
 
-    return expect(cmd.run({
+    return cmd.run({
       app: 'myapp',
       args: {addon_name: 'postgres-123'},
       flags: {credential: 'hello'}
-    }), 'to be rejected with error satisfying', new Error('Could not find credential hello for database postgres-123'))
+    })
+    .then(() => { throw new Error('unreachable') })
+    .catch((err) => expect(err.message, 'to equal', 'Could not find credential hello for database postgres-123'))
   })
 })

--- a/test/commands/addons/create.js
+++ b/test/commands/addons/create.js
@@ -51,11 +51,13 @@ describe('addons:create', () => {
 
   context('calling addons:create without a plan', () => {
     it('errors out with usage', () => {
-      return expect(cmd.run({
+      return cmd.run({
         app: 'myapp',
         args: [],
         flags: {name: 'foobar'}
-      }), 'to be rejected with error satisfying', new Error('Usage: heroku addons:create SERVICE:PLAN'))
+      })
+      .then(() => { throw new Error('unreachable') })
+      .catch((err) => expect(err.message, 'to equal', 'Usage: heroku addons:create SERVICE:PLAN'))
     })
   })
 
@@ -249,7 +251,9 @@ Use heroku addons:docs heroku-db3 to view documentation
           flags: {as: 'mydb'}
         })
 
-        expect(cmdPromise, 'to be rejected with', 'The add-on was unable to be created, with status deprovisioned')
+        return cmdPromise
+        .then(() => { throw new Error('unreachable') })
+        .catch((err) => expect(err.message, 'to equal', 'The add-on was unable to be created, with status deprovisioned'))
       })
     })
   })

--- a/test/commands/addons/destroy.js
+++ b/test/commands/addons/destroy.js
@@ -28,9 +28,11 @@ describe('addons:destroy', () => {
     let api = nock('https://api.heroku.com:443')
       .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'heroku-db4'}).reply(200, [addon])
 
-    return expect(
-      cmd.run({app: 'myapp', args: ['heroku-db4'], flags: {confirm: 'myapp'}}),
-      'to be rejected with', 'db4-swiftly-123 is on myotherapp not myapp'
-    ).then(() => api.done())
+    return cmd.run({app: 'myapp', args: ['heroku-db4'], flags: {confirm: 'myapp'}})
+    .then(() => { throw new Error('unreachable') })
+    .catch((err) => {
+      api.done()
+      expect(err.message, 'to equal', 'db4-swiftly-123 is on myotherapp not myapp')
+    })
   })
 })

--- a/test/commands/addons/rename.js
+++ b/test/commands/addons/rename.js
@@ -38,8 +38,9 @@ describe('addons:rename', () => {
         .get('/addons/not-an-addon')
         .reply(404, {message: "Couldn't find that add-on.", id: 'not_found', resource: 'addon'})
 
-      return expect(cmd.run({flags: {}, args: {addon: 'not-an-addon', name: 'cache-redis'}}),
-        'to be rejected with', {body: {message: "Couldn't find that add-on."}})
+      return cmd.run({flags: {}, args: {addon: 'not-an-addon', name: 'cache-redis'}})
+      .then(() => { throw new Error('unreachable') })
+      .catch((err) => expect(err, 'to satisfy', {body: {message: "Couldn't find that add-on."}}))
     })
   })
 })

--- a/test/commands/addons/wait.js
+++ b/test/commands/addons/wait.js
@@ -77,10 +77,9 @@ describe('addons:wait', function () {
         nock('https://api.heroku.com', {reqheaders: expansionHeaders})
           .get('/apps/acme-inc-www/addons/www-redis')
           .reply(200, deprovisionedAddon)
-
-        let cmdPromise = cmd.run({flags: {}, args: {addon: 'www-redis'}})
-
-        expect(cmdPromise, 'to be rejected with', 'The add-on was unable to be created, with status deprovisioned')
+        return cmd.run({flags: {}, args: {addon: 'www-redis'}})
+        .then(() => { throw new Error('unreachable') })
+        .catch((err) => expect(err.message, 'to equal', 'The add-on was unable to be created, with status deprovisioned'))
       })
     })
   })

--- a/test/lib/resolve.js
+++ b/test/lib/resolve.js
@@ -393,10 +393,14 @@ describe('resolve', () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', {'app': 'myapp', 'addon_attachment': 'myattachment-4'}).reply(404, {'resource': 'app'})
 
+      let appAddon = nock('https://api.heroku.com:443')
+        .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'myattachment-4'}).reply(200, [{id: '1e97e8ba-fd24-48a4-8118-eaf287eb7a0f', name: 'myaddon-4'}])
+
       return resolve.attachment(new Heroku(), 'myapp', 'myattachment-4')
         .then(() => { throw new Error('unreachable') })
         .catch((err) => expect(err, 'to satisfy', {body: {'resource': 'app'}}))
         .then(() => api.done())
+        .then(() => appAddon.done())
     })
 
     it('throws an error when not found with addon_service', () => {


### PR DESCRIPTION
@jdxcode @RasPhilCo the circle build was still using npm & node 6 for testing and sometime since someone last worked on this, the build started failing.  So I switched it over to yarn based dependencies so that we get predictable builds.  Then I bumped the node version up to 9 so that we actually test against what we use in the CLI.  There were a bunch of rejected promises warnings and I had to clean up some code to fix.  When cleaning up code I found that the `to be rejected with` tests were not actually failing so I replaced them with the longhand version.