### PR TITLE
Remove 3.with-addon-billing-info variant

### DIFF
--- a/commands/addons/index.js
+++ b/commands/addons/index.js
@@ -24,8 +24,7 @@ function * run (ctx, api) {
 
     if (app) { // don't disploy attachments globally
       addons = api.get(`/apps/${app}/addons`, {headers: {
-        'Accept-Expansion': 'addon_service,plan',
-        'Accept': 'application/vnd.heroku+json; version=3.with-addon-billing-info'
+        'Accept-Expansion': 'addon_service,plan'
       }})
 
       let sudoHeaders = JSON.parse(process.env.HEROKU_HEADERS || '{}')
@@ -47,8 +46,7 @@ function * run (ctx, api) {
         method: 'GET',
         path: '/addons',
         headers: {
-          'Accept-Expansion': 'addon_service,plan',
-          'Accept': 'application/vnd.heroku+json; version=3.with-addon-billing-info'
+          'Accept-Expansion': 'addon_service,plan'
         }
       })
     }

--- a/commands/addons/info.js
+++ b/commands/addons/info.js
@@ -11,19 +11,11 @@ let style = require('../../lib/util').style
 let run = cli.command({preauth: true}, function (ctx, api) {
   const resolve = require('../../lib/resolve')
   return co(function * () {
-    let resolvedAddon = yield resolve.addon(api, ctx.app, ctx.args.addon)
-
-    // the resolve call uses a variant so we cannot also use the
-    // with-addon-billing-info in the resolve call so we have to run out
-    // and grab the addon again, but can bundle with the attachments request
-    let [addon, attachments] = yield [
-      api.get(`/addons/${resolvedAddon.id}`, {headers: {
-        'Accept-Expansion': 'addon_service,plan',
-        'Accept': 'application/vnd.heroku+json; version=3.with-addon-billing-info'
-      }}),
+    let addon = yield resolve.addon(api, ctx.app, ctx.args.addon)
+    let [attachments] = yield [
       api.request({
         method: 'GET',
-        path: `/addons/${resolvedAddon.id}/addon-attachments`
+        path: `/addons/${addon.id}/addon-attachments`
       })
     ]
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,7 +25,7 @@ module.exports = {
 
   grandfatheredPrice: function (addon) {
     const price = addon.plan.price
-    return Object.assign({}, price, {cents: addon.billed_price_cents})
+    return Object.assign({}, price, {cents: addon.billed_price.cents})
   },
 
   formatPrice: function (price) {

--- a/test/commands/addons.--all.js
+++ b/test/commands/addons.--all.js
@@ -55,11 +55,10 @@ acme-inc-www  www-redis  heroku-redis:premium-2       $60/month  creating`)
   context('with a grandfathered add-on', function () {
     beforeEach(function () {
       let addon = fixtures.addons['dwh-db']
-      addon.billed_price_cents = 10000
+      addon.billed_price = { cents: 10000 }
 
       nock('https://api.heroku.com', {reqheaders: {
-        'Accept-Expansion': 'addon_service,plan',
-        'Accept': 'application/vnd.heroku+json; version=3.with-addon-billing-info'
+        'Accept-Expansion': 'addon_service,plan'
       }})
         .get('/addons')
         .reply(200, [addon])

--- a/test/commands/addons.--app.js
+++ b/test/commands/addons.--app.js
@@ -14,8 +14,7 @@ describe('addons --app', function () {
     attachments = attachments || []
 
     nock('https://api.heroku.com', {reqheaders: {
-      'Accept-Expansion': 'addon_service,plan',
-      'Accept': 'application/vnd.heroku+json; version=3.with-addon-billing-info'
+      'Accept-Expansion': 'addon_service,plan'
     }})
       .get(`/apps/${appName}/addons`)
       .reply(200, addons)
@@ -246,7 +245,7 @@ The table above shows add-ons and the attachments to the current app (acme-inc-d
   context('with a grandfathered add-on', function () {
     beforeEach(function () {
       let addon = fixtures.addons['dwh-db']
-      addon.billed_price_cents = 10000
+      addon.billed_price = {cents: 10000}
 
       mockAPI('acme-inc-dwh', [
         addon

--- a/test/commands/addons/info.js
+++ b/test/commands/addons/info.js
@@ -20,8 +20,7 @@ describe('addons:info', function () {
         .reply(200, [fixtures.addons['www-db']])
 
       nock('https://api.heroku.com', {reqheaders: {
-        'Accept-Expansion': 'addon_service,plan',
-        'Accept': 'application/vnd.heroku+json; version=3.with-addon-billing-info'
+        'Accept-Expansion': 'addon_service,plan'
       }})
         .get(`/addons/${fixtures.addons['www-db']['id']}`)
         .reply(200, fixtures.addons['www-db'])
@@ -53,8 +52,7 @@ State:        created
         .reply(200, [fixtures.addons['www-db']])
 
       nock('https://api.heroku.com', {reqheaders: {
-        'Accept-Expansion': 'addon_service,plan',
-        'Accept': 'application/vnd.heroku+json; version=3.with-addon-billing-info'
+        'Accept-Expansion': 'addon_service,plan'
       }})
         .get(`/addons/${fixtures.addons['www-db']['id']}`)
         .reply(200, fixtures.addons['www-db'])
@@ -89,8 +87,7 @@ State:        created
         .reply(200, fixtures.addons['www-db'])
 
       nock('https://api.heroku.com', {reqheaders: {
-        'Accept-Expansion': 'addon_service,plan',
-        'Accept': 'application/vnd.heroku+json; version=3.with-addon-billing-info'
+        'Accept-Expansion': 'addon_service,plan'
       }})
         .get(`/addons/${fixtures.addons['www-db']['id']}`)
         .reply(200, fixtures.addons['www-db'])
@@ -117,15 +114,14 @@ State:        created
   context('with add-ons', function () {
     beforeEach(function () {
       let addon = fixtures.addons['dwh-db']
-      addon.billed_price_cents = 10000
+      addon.billed_price = { cents: 10000 }
 
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
         .post('/actions/addons/resolve', {'app': null, 'addon': 'dwh-db'})
         .reply(200, [addon])
 
       nock('https://api.heroku.com', {reqheaders: {
-        'Accept-Expansion': 'addon_service,plan',
-        'Accept': 'application/vnd.heroku+json; version=3.with-addon-billing-info'
+        'Accept-Expansion': 'addon_service,plan'
       }})
         .get(`/addons/${addon['id']}`)
         .reply(200, addon)

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -100,7 +100,9 @@ fixtures.addons = {
     addon_service: fixtures.services['heroku-postgresql'],
     plan: fixtures.plans['heroku-postgresql:hobby-dev'],
     state: 'provisioned',
-    billed_price_cents: 0
+    billed_price: {
+      cents: 0
+    }
   },
   'www-redis': {
     app: fixtures.apps.www,
@@ -109,7 +111,9 @@ fixtures.addons = {
     addon_service: fixtures.services['heroku-redis'],
     plan: fixtures.plans['heroku-redis:premium-2'],
     state: 'provisioning',
-    billed_price_cents: 6000
+    billed_price: {
+      cents: 6000
+    }
   },
   'api-redis': {
     app: fixtures.apps.api,
@@ -118,7 +122,9 @@ fixtures.addons = {
     addon_service: fixtures.services['heroku-redis'],
     plan: fixtures.plans['heroku-redis:premium-2'],
     state: 'provisioned',
-    billed_price_cents: 6000
+    billed_price: {
+      cents: 6000
+    }
   },
   'dwh-test-db': {
     app: fixtures.apps.dwh,
@@ -127,7 +133,9 @@ fixtures.addons = {
     addon_service: fixtures.services['heroku-postgresql'],
     plan: fixtures.plans['heroku-postgresql:hobby-dev'],
     state: 'provisioned',
-    billed_price_cents: 0
+    billed_price: {
+      cents: 0
+    }
   },
   'dwh-db': {
     app: fixtures.apps.dwh,
@@ -136,7 +144,9 @@ fixtures.addons = {
     addon_service: fixtures.services['heroku-postgresql'],
     plan: fixtures.plans['heroku-postgresql:standard-2'],
     state: 'provisioned',
-    billed_price_cents: 20000
+    billed_price: {
+      cents: 20000
+    }
   },
   'dwh-db-2': {
     app: fixtures.apps.dwh,
@@ -145,7 +155,9 @@ fixtures.addons = {
     addon_service: fixtures.services['heroku-postgresql'],
     plan: fixtures.plans['heroku-postgresql:standard-2'],
     state: 'provisioned',
-    billed_price_cents: 20000
+    billed_price: {
+      cents: 20000
+    }
   }
 }
 


### PR DESCRIPTION
@jdxcode @RasPhilCo could you review?  This uses the publicly available attribute instead of a variant.  This allowed us to get rid an extra request as well, which is nice.