### PR TITLE
Show contract for addon / plans when contract

### DIFF
--- a/commands/addons/plans.js
+++ b/commands/addons/plans.js
@@ -8,7 +8,7 @@ function * run (context, heroku) {
   const _ = require('lodash')
 
   let plans = yield heroku.get(`/addon-services/${context.args.service}/plans`)
-  plans = _.sortBy(plans, 'price.cents')
+  plans = _.sortBy(plans, ['price.contract', 'price.cents'])
 
   if (context.flags.json) {
     cli.styledJSON(plans)

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,13 +24,17 @@ module.exports = {
 
   grandfatheredPrice: function (addon) {
     const price = addon.plan.price
-    return Object.assign({}, price, {cents: addon.billed_price.cents})
+    return Object.assign({}, price, {
+      cents: addon.billed_price.cents,
+      contract: addon.billed_price.contract
+    })
   },
 
   formatPrice: function (price) {
     const printf = require('printf')
 
     if (!price) return
+    if (price.contract) return 'contract'
     if (price.cents === 0) return 'free'
 
     let fmt = price.cents % 100 === 0 ? '$%.0f/%s' : '$%.02f/%s'

--- a/test/commands/addons.--all.js
+++ b/test/commands/addons.--all.js
@@ -74,6 +74,28 @@ acme-inc-dwh  dwh-db  heroku-postgresql:standard-2  $100/month  created`)
     })
   })
 
+  context('with a contract add-on', function () {
+    beforeEach(function () {
+      let addon = fixtures.addons['dwh-db']
+      addon.billed_price = { cents: 0, contract: true }
+
+      nock('https://api.heroku.com', {reqheaders: {
+        'Accept-Expansion': 'addon_service,plan'
+      }})
+        .get('/addons')
+        .reply(200, [addon])
+    })
+
+    it('prints add-ons in a table with contract', function () {
+      return cmd.run({flags: {}}).then(function () {
+        util.expectOutput(cli.stdout,
+          `Owning App    Add-on  Plan                          Price     State
+────────────  ──────  ────────────────────────────  ────────  ───────
+acme-inc-dwh  dwh-db  heroku-postgresql:standard-2  contract  created`)
+      })
+    })
+  })
+
   it('prints message when there are no add-ons', function () {
     nock('https://api.heroku.com').get('/addons').reply(200, [])
     return cmd.run({flags: {}}).then(function () {

--- a/test/commands/addons.--app.js
+++ b/test/commands/addons.--app.js
@@ -266,6 +266,30 @@ The table above shows add-ons and the attachments to the current app (acme-inc-d
     })
   })
 
+  context('with a contract add-on', function () {
+    beforeEach(function () {
+      let addon = fixtures.addons['dwh-db']
+      addon.billed_price = {cents: 0, contract: true}
+
+      mockAPI('acme-inc-dwh', [
+        addon
+      ], [
+        fixtures.attachments['acme-inc-dwh::DATABASE']
+      ])
+    })
+
+    it('prints add-ons in a table with contract', function () {
+      return run('acme-inc-dwh', function () {
+        util.expectOutput(cli.stdout,
+          `Add-on                      Plan        Price     State
+──────────────────────────  ──────────  ────────  ───────
+heroku-postgresql (dwh-db)  standard-2  contract  created
+ └─ as DATABASE
+The table above shows add-ons and the attachments to the current app (acme-inc-dwh) or other apps.`)
+      })
+    })
+  })
+
   it('prints add-on line for attachment when add-on info is missing from API (e.g. no permissions on billing app)', function () {
     mockAPI('acme-inc-api', [ /* no add-on ! */], [fixtures.attachments['acme-inc-api::WWW_DB']])
 

--- a/test/commands/addons/info.js
+++ b/test/commands/addons/info.js
@@ -6,11 +6,13 @@ let util = require('../../util')
 let cli = require('heroku-cli-util')
 let nock = require('nock')
 let cmd = require('../../../commands/addons/info')
+let cache = require('../../../lib/resolve').addon.cache
 
 describe('addons:info', function () {
   beforeEach(function () {
     cli.mockConsole()
     nock.cleanAll()
+    cache.clear()
   })
 
   context('with add-ons', function () {
@@ -80,6 +82,10 @@ State:        created
   context('with app but not an app add-on', function () {
     beforeEach(function () {
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+        .post('/actions/addons/resolve', {'app': 'example', 'addon': 'www-db'})
+        .reply(200, [fixtures.addons['www-db']])
+
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
         .get('/apps/example/addons/www-db')
         .reply(404)
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
@@ -140,6 +146,41 @@ Installed at: Invalid Date
 Owning app:   acme-inc-dwh
 Plan:         heroku-postgresql:standard-2
 Price:        $100/month
+State:        created
+`)
+      })
+    })
+  })
+
+  context('with a contract add-on', function () {
+    beforeEach(function () {
+      let addon = fixtures.addons['dwh-db']
+      addon.billed_price = { cents: 0, contract: true }
+
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+        .post('/actions/addons/resolve', {'app': null, 'addon': 'dwh-db'})
+        .reply(200, [addon])
+
+      nock('https://api.heroku.com', {reqheaders: {
+        'Accept-Expansion': 'addon_service,plan'
+      }})
+        .get(`/addons/${addon['id']}`)
+        .reply(200, addon)
+
+      nock('https://api.heroku.com')
+        .get(`/addons/${fixtures.addons['dwh-db']['id']}/addon-attachments`)
+        .reply(200, [fixtures.attachments['acme-inc-dwh::DATABASE']])
+    })
+
+    it('prints add-ons in a table with contract', function () {
+      return cmd.run({flags: {}, args: {addon: 'dwh-db'}}).then(function () {
+        util.expectOutput(cli.stdout,
+          `=== dwh-db
+Attachments:  acme-inc-dwh::DATABASE
+Installed at: Invalid Date
+Owning app:   acme-inc-dwh
+Plan:         heroku-postgresql:standard-2
+Price:        contract
 State:        created
 `)
       })

--- a/test/commands/addons/plans.js
+++ b/test/commands/addons/plans.js
@@ -10,14 +10,18 @@ describe('addons:plans', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/addon-services/daservice/plans')
       .reply(200, [
-        {name: 'first', human_name: 'First', price: {cents: 0, unit: 'month'}, default: true},
-        {name: 'second', human_name: 'Second', price: {cents: 1000, unit: 'month'}, default: false}
+        {name: 'first', human_name: 'First', price: {cents: 0, unit: 'month', contract: false}, default: true},
+        {name: 'second', human_name: 'Second', price: {cents: 2000, unit: 'month', contract: false}, default: false},
+        {name: 'third', human_name: 'Third', price: {cents: 10000, unit: 'month', contract: false}, default: false},
+        {name: 'fourth', human_name: 'Fourth', price: {cents: 0, unit: 'month', contract: true}, default: false}
       ])
     return cmd.run({args: {service: 'daservice'}, flags: {}})
       .then(() => expect(cli.stdout).to.equal(`         slug    name    price
-───────  ──────  ──────  ─────────
+───────  ──────  ──────  ──────────
 default  first   First   free
-         second  Second  $10/month
+         second  Second  $20/month
+         third   Third   $100/month
+         fourth  Fourth  contract
 `))
       .then(() => api.done())
   })

--- a/test/commands/addons/upgrade.js
+++ b/test/commands/addons/upgrade.js
@@ -3,8 +3,14 @@
 
 let cmd = commands.find((c) => c.topic === 'addons' && c.command === 'upgrade')
 let expect = require('unexpected')
+let cache = require('../../../lib/resolve').addon.cache
+
 describe('addons:upgrade', () => {
-  beforeEach(() => cli.mockConsole())
+  beforeEach(() => {
+    cli.mockConsole()
+    cache.clear()
+  })
+
   afterEach(() => nock.cleanAll())
 
   it('upgrades an add-on', () => {
@@ -17,6 +23,19 @@ describe('addons:upgrade', () => {
     return cmd.run({app: 'myapp', args: {addon: 'heroku-kafka', plan: 'heroku-kafka:hobby'}})
       .then(() => expect(cli.stdout, 'to equal', 'provision msg\n'))
       .then(() => expect(cli.stderr, 'to equal', 'Changing kafka-swiftly-123 on myapp from premium-0 to heroku-kafka:hobby... done, free\n'))
+      .then(() => api.done())
+  })
+
+  it('upgrades to a contract add-on', () => {
+    let addon = {name: 'connect-swiftly-123', addon_service: {name: 'heroku-connect'}, app: {name: 'myapp'}, plan: {name: 'free'}}
+
+    let api = nock('https://api.heroku.com:443')
+      .post('/actions/addons/resolve', {'app': 'myapp', 'addon': 'heroku-connect'}).reply(200, [addon])
+      .patch('/apps/myapp/addons/connect-swiftly-123', {plan: {name: 'heroku-connect:contract'}})
+      .reply(200, {plan: {price: {cents: 0, contract: true}}, provision_message: 'provision msg'})
+    return cmd.run({app: 'myapp', args: {addon: 'heroku-connect', plan: 'heroku-connect:contract'}})
+      .then(() => expect(cli.stdout, 'to equal', 'provision msg\n'))
+      .then(() => expect(cli.stderr, 'to equal', 'Changing connect-swiftly-123 on myapp from free to heroku-connect:contract... done, contract\n'))
       .then(() => api.done())
   })
 


### PR DESCRIPTION
Connect wants us to show `contract` instead of `free` for their contractually negotiated add-ons which are billed outside of the normal add-on billing.  The data on plans / add-ons is already present in API so this is ready to go.  For more info see the [trello card](https://trello.com/c/MUt8EPH9/578-contract-plans-provision-able-paid-plans-w-o-a-displayed-price-in-elements).